### PR TITLE
_websocket_handler waits on writer even after the socket is closed

### DIFF
--- a/engineio/socket.py
+++ b/engineio/socket.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 import time
 import six
+import socket
 
 from . import packet
 from . import payload
@@ -150,7 +152,7 @@ class Socket(object):
                 try:
                     for pkt in packets:
                         ws.send(pkt.encode(always_bytes=False))
-                except:
+                except socket.error:
                     break
 
         writer_task = self.server.start_background_task(writer)
@@ -173,4 +175,5 @@ class Socket(object):
             except ValueError:
                 pass
         self.close(wait=False, abort=True)
+        self.queue.put(packet.Packet(packet.NOOP))  # wakeup the writer
         writer_task.join()


### PR DESCRIPTION
This patch wakes up the writer with a null message when the socket gets closed. Without this the writer() waits unnecessarily which makes the serving thread to wait longer.