### PR TITLE
Polling: allow GET requests until send queue is empty

### DIFF
--- a/engineio/socket.py
+++ b/engineio/socket.py
@@ -18,6 +18,7 @@ class Socket(object):
         self.connected = False
         self.upgraded = False
         self.closed = False
+        self.writeable = True
 
     def poll(self):
         """Wait for packets to send to the client."""
@@ -50,7 +51,7 @@ class Socket(object):
 
     def send(self, pkt):
         """Send a packet to the client."""
-        if self.closed:
+        if self.closed or not self.writeable:
             raise IOError('Socket is closed')
         if time.time() - self.last_ping > self.server.ping_interval * 5 / 4:
             self.server.logger.info('%s: Client is gone, closing socket',
@@ -96,9 +97,10 @@ class Socket(object):
         self.server._trigger_event('disconnect', self.sid)
         if not abort:
             self.send(packet.Packet(packet.CLOSE))
-        self.closed = True
+        self.writeable = False
         if wait:
             self.queue.join()
+        self.closed = True
 
     def _upgrade_websocket(self, environ, start_response):
         """Upgrade the connection from polling to websocket."""


### PR DESCRIPTION
When using polling transport, calling close() blocks GET requests so CLOSE packet can't be sent.

This pull request adds a writeable flag that block send() until the socket can be actually closed
