### PR TITLE
Fixed possible starvation issue during upgrading to WebSocket transport

### DIFF
--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -209,7 +209,7 @@ class TestSocket(unittest.TestCase):
         s._websocket_handler(ws)
         ws.send.assert_called_once_with(packet.Packet(
             packet.PONG, data=probe).encode(always_bytes=False))
-        self.assertEqual(s.queue.get().packet_type, packet.NOOP)
+        self.assertEqual(s.queue.get(block=False).packet_type, packet.NOOP)
         self.assertFalse(s.upgraded)
 
     def test_upgrade_not_supported(self):


### PR DESCRIPTION
This pull request fixes a possible starvation issue that prevents the socket from being upgraded from polling to WebSocket transport if the outbound packet queue is filled too fast from other (green) threads.

I have stumbled upon the issue while building a WebSocket service that generates packets with a high frequency. In our case, the packets represent measurements that come from external devices with a frequency > 100 Hz, so there are more than 100 packets per second. When a new client tried to connect to the service, we have found that the upgrade to the WebSocket transport blocked in the line where we were waiting for the outbound packet queue to become empty (i.e. a `self.queue.join()` call). This happened because the polling transport was not fast enough to drain the packet queue faster than it was filled from the other end by the measurement thread. (The WebSocket transport would have been fast enough, though).

The patch fixes the problem by storing outbound packets generated during the upgrade in a temporary "backlog" queue so the "real" outbound queue has a chance to become empty, allowing the transport upgrade to proceed. When the transport is upgraded to WebSocket, the backlog is flushed and then the backlog queue is deleted.
