### PR TITLE
Starting thread in daemon mode

### DIFF
--- a/engineio/server.py
+++ b/engineio/server.py
@@ -281,7 +281,8 @@ class Server(object):
         """
         th = getattr(self.async['threading'],
                      self.async['thread_class'])(target=target, args=args,
-                                                 kwargs=kwargs, daemon=True)
+                                                 kwargs=kwargs)
+        th.daemon = True
         th.start()
         return th  # pragma: no cover
 

--- a/engineio/server.py
+++ b/engineio/server.py
@@ -281,7 +281,7 @@ class Server(object):
         """
         th = getattr(self.async['threading'],
                      self.async['thread_class'])(target=target, args=args,
-                                                 kwargs=kwargs)
+                                                 kwargs=kwargs, daemon=True)
         th.start()
         return th  # pragma: no cover
 


### PR DESCRIPTION
Starting thread in daemon mode, so it no longer blocks the main process when closing.
Like I said at [flask-socketio](https://github.com/miguelgrinberg/Flask-SocketIO/issues/237) , I'm not entirely sure it's a good idea, but all the async_mode I've seen use the std Thread class which supports the daemon attribute.

Here is some documentation about the attribute : https://docs.python.org/2/library/threading.html#threading.Thread.daemon
https://docs.python.org/3/library/threading.html#threading.Thread.daemon
