### PR TITLE
Prevent raising an error so thread handling the redis won't die

### DIFF
--- a/engineio/server.py
+++ b/engineio/server.py
@@ -336,8 +336,8 @@ class Server(object):
         except KeyError:
             raise KeyError('Session not found')
         if s.closed:
-            del self.sockets[sid]
-            raise KeyError('Session is disconnected')
+            if sid in self.sockets:
+                del self.sockets[sid]
         return s
 
     def _ok(self, packets=None, headers=None, b64=False):


### PR DESCRIPTION
I added an issue in the other repo. This fix seems to have resolve it so far.

[https://github.com/miguelgrinberg/Flask-SocketIO/issues/263](url)