### PR TITLE
holdtime for  server to have a flexible timer when marking the client as close

### DIFF
--- a/engineio/server.py
+++ b/engineio/server.py
@@ -27,6 +27,8 @@ class Server(object):
                          server to respond before disconnecting.
     :param ping_interval: The interval in seconds at which the client pings
                           the server.
+    :param ping_holdtime: The time in which the server considers the client as 
+                          timeout. (Recommended 3 times of ping_interval)
     :param max_http_buffer_size: The maximum size of a message when using the
                                  polling transport.
     :param allow_upgrades: Whether to allow transport upgrades or not.
@@ -57,9 +59,12 @@ class Server(object):
                  max_http_buffer_size=100000000, allow_upgrades=True,
                  http_compression=True, compression_threshold=1024,
                  cookie='io', cors_allowed_origins=None,
-                 cors_credentials=True, logger=False, json=None, **kwargs):
+                 cors_credentials=True, logger=False, json=None, 
+                 ping_holdtime=75,
+                 **kwargs):
         self.ping_timeout = ping_timeout
         self.ping_interval = ping_interval
+        self.ping_holdtime = ping_holdtime
         self.max_http_buffer_size = max_http_buffer_size
         self.allow_upgrades = allow_upgrades
         self.http_compression = http_compression

--- a/engineio/socket.py
+++ b/engineio/socket.py
@@ -55,7 +55,7 @@ class Socket(object):
         """Send a packet to the client."""
         if self.closed:
             raise IOError('Socket is closed')
-        if time.time() - self.last_ping > self.server.ping_interval * 5 / 4:
+        if time.time() - self.last_ping > self.server.ping_holdtime:
             self.server.logger.info('%s: Client is gone, closing socket',
                                     self.sid)
             self.close(wait=False, abort=True)

--- a/engineio/socket.py
+++ b/engineio/socket.py
@@ -56,7 +56,7 @@ class Socket(object):
         if self.closed:
             raise IOError('Socket is closed')
         if time.time() - self.last_ping > self.server.ping_holdtime:
-            self.server.logger.info('%s: Client is gone, closing socket',
+            self.server.logger.info('%s: Client is beyond hold timer, closing socket',
                                     self.sid)
             self.close(wait=False, abort=True)
             return

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -20,6 +20,7 @@ class TestSocket(unittest.TestCase):
         mock_server = mock.Mock()
         mock_server.ping_timeout = 0.2
         mock_server.ping_interval = 0.2
+        mock_server.ping_holdtime = 0.6
 
         try:
             import queue


### PR DESCRIPTION
Dear Miguel,

This is an implementation of my ping_holdtime patterned after the BGP & LDP hello/keepalive holdtime.

Base on a series of tests on my redis/eventlet environment, with 
- very low ping_interval= 2
- high burst of traffic = .8 msg/per sec + another 1 msg/per sec
- and multiple connection 30+  ( I know 30 is very low )

I have found out that some clients are timing out due to a busy processing on the server end.  With the additional latency from redis and pub/sub processing overhead to send messages to multiple clients, the 25% leeway on the ping interval calculation might not be enough in certain use cases. 
