### PR TITLE
Allow lower version of six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'six>=1.9.0',
+        'six>=1.5.2',
     ],
     tests_require=[
         'mock',


### PR DESCRIPTION
It seems that v1.5.2 is sufficient (because the tests pass). We could probably go lower, but [Ubuntu 14.04's packaged version](http://packages.ubuntu.com/trusty/python-six) seems like a nice standard.

Was there any particular reason to choose v1.9.0 originally?