### PR TITLE
Optionally pass environ to message event handler

### DIFF
--- a/engineio/server.py
+++ b/engineio/server.py
@@ -50,6 +50,9 @@ class Server(object):
     :param async_handlers: If set to ``True``, run message event handlers in
                            non-blocking threads. To run handlers synchronously,
                            set to ``False``. The default is ``True``.
+    :param pass_environ: If set to ``True``, the current ``environ`` is passed
+                         to the ``"message"`` event handler as second argument
+                         (right after ``sid``). (default is ``False``)
     :param kwargs: Reserved for future extensions, any additional parameters
                    given as keyword arguments will be silently ignored.
     """
@@ -61,7 +64,7 @@ class Server(object):
                  http_compression=True, compression_threshold=1024,
                  cookie='io', cors_allowed_origins=None,
                  cors_credentials=True, logger=False, json=None,
-                 async_handlers=True, **kwargs):
+                 async_handlers=True, pass_environ=False, **kwargs):
         self.ping_timeout = ping_timeout
         self.ping_interval = ping_interval
         self.max_http_buffer_size = max_http_buffer_size
@@ -72,6 +75,7 @@ class Server(object):
         self.cors_allowed_origins = cors_allowed_origins
         self.cors_credentials = cors_credentials
         self.async_handlers = async_handlers
+        self.pass_environ = pass_environ
         self.sockets = {}
         self.handlers = {}
         if json is not None:
@@ -230,8 +234,6 @@ class Server(object):
                         self.logger.warning('Invalid session %s', sid)
                         r = self._bad_request()
                     else:
-                        self._trigger_event('connect_update', sid, environ,
-                                            async=False)
                         socket = self._get_socket(sid)
                         try:
                             packets = socket.handle_get_request(

--- a/engineio/server.py
+++ b/engineio/server.py
@@ -230,6 +230,8 @@ class Server(object):
                         self.logger.warning('Invalid session %s', sid)
                         r = self._bad_request()
                     else:
+                        self._trigger_event('connect_update', sid, environ,
+                                            async=False)
                         socket = self._get_socket(sid)
                         try:
                             packets = socket.handle_get_request(

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -21,6 +21,7 @@ class TestSocket(unittest.TestCase):
         mock_server.ping_timeout = 0.2
         mock_server.ping_interval = 0.2
         mock_server.async_handlers = True
+        mock_server.pass_environ = False
 
         try:
             import queue


### PR DESCRIPTION
I was looking for a method to always have the current `environ` at hand in an event handler. For that to work, I added the `pass_environ` keyword argument to `engineio.Server` initialization with a default of `False`. If it is set to `True`, the current `environ` is passed to the event handler for `'message'` as second argument, after `sid`.

By _current_ `environ` I mean the one belonging to a particular event triggering.

This behaviour ensures backwards compatibility and is not noticeable for those who don't enable it explicitly.

I also wrote an addition to the `socketio` library to let it pass through the `environ` to it's registered event handlers. I'll submit another pull request for that part.
