### PR TITLE
Fix handle ping timeout from bad client.

### DIFF
--- a/engineio/socket.py
+++ b/engineio/socket.py
@@ -220,6 +220,6 @@ class Socket(object):
 
         self.queue.put(None)  # unlock the writer task so that it can exit
         writer_task.join()
-        self.close(wait=True, abort=True)
+        self.close(wait=False, abort=True)
 
         return []


### PR DESCRIPTION
If `wait=True` method `close()` can hang forever on `self.queue.join()` because `writer_task` already completed (by `writer_task.join()`) and no one empty the queue.

## Test case

### server.py

```python
from flask import Flask
from flask_socketio import SocketIO

app = Flask(__name__)
socketio = SocketIO(
    app, async_mode='eventlet', logger=True, engineio_logger=True,
    # ping_timeout=1,  # <-- uncomment for quick test
)


if __name__ == '__main__':
    socketio.run(app, port=9999, log_output=True, debug=True)
```

### client.py
```python

import logging
import time
from multiprocessing import Process
import signal
import os


from socketIO_client import SocketIO

logging.basicConfig(level=logging.NOTSET)


def client():
    conn = SocketIO('localhost', 9999, logger=True, engineio_logger=True)
    time.sleep(999)  # prevent client exit until kill


p = Process(target=client)
p.start()
time.sleep(5)

print('[!] hard suspending client longer than ping_timeout')
os.kill(p.pid, signal.SIGSTOP)
time.sleep(60)  # <- ping_timeout

print('[!] terminate client')
os.kill(p.pid, signal.SIGKILL)
```

### Additional

The main problem in this case that `_websocket_handler()` will never exit and all object will stay in memory (memory leak). 

I think this problem also correlates with https://github.com/miguelgrinberg/python-engineio/pull/51.
