### PR TITLE
aiohttp>=3 expects the WebSocketResponse.send_str and WebSocketRespon…

### DIFF
--- a/engineio/async_aiohttp.py
+++ b/engineio/async_aiohttp.py
@@ -101,7 +101,7 @@ class WebSocket(object):  # pragma: no cover
 
     async def send(self, message):
         async def call_async_conditionally(func, arguments):
-            if inspect.iscoroutinefunction(object):
+            if inspect.iscoroutinefunction(func):
                 await func(arguments)
             else:
                 func(arguments)

--- a/engineio/async_aiohttp.py
+++ b/engineio/async_aiohttp.py
@@ -3,6 +3,7 @@ from urllib.parse import urlsplit
 
 import aiohttp
 import six
+import inspect
 
 
 def create_route(app, engineio_server, engineio_endpoint):
@@ -99,10 +100,16 @@ class WebSocket(object):  # pragma: no cover
         await self._sock.close()
 
     async def send(self, message):
+        async def call_async_conditionally(func, arguments):
+            if inspect.iscoroutinefunction(object):
+                await func(arguments)
+            else:
+                func(arguments)
+
         if isinstance(message, bytes):
-            self._sock.send_bytes(message)
+            await call_async_conditionally(self._sock.send_bytes, message)
         else:
-            self._sock.send_str(message)
+            await call_async_conditionally(self._sock.send_str, message)
 
     async def wait(self):
         msg = await self._sock.receive()

--- a/tests/test_async_aiohttp.py
+++ b/tests/test_async_aiohttp.py
@@ -8,7 +8,7 @@ else:
     import mock
 
 if sys.version_info >= (3, 5):
-    from aiohttp import web, hdrs
+    from aiohttp import web
     from engineio import async_aiohttp
 
 

--- a/tests/test_async_aiohttp.py
+++ b/tests/test_async_aiohttp.py
@@ -8,20 +8,20 @@ else:
     import mock
 
 if sys.version_info >= (3, 5):
-    from aiohttp import web
+    from aiohttp import web, hdrs
     from engineio import async_aiohttp
 
 
 @unittest.skipIf(sys.version_info < (3, 5), 'only for Python 3.5+')
 class AiohttpTests(unittest.TestCase):
-    @mock.patch('aiohttp.web_urldispatcher.UrlDispatcher.add_route')
-    def test_create_route(self, add_route):
+    @mock.patch('aiohttp.web_urldispatcher.UrlDispatcher.add_get')
+    @mock.patch('aiohttp.web_urldispatcher.UrlDispatcher.add_post')
+    def test_create_route(self, add_post, add_get):
         app = web.Application()
         mock_server = mock.MagicMock()
         async_aiohttp.create_route(app, mock_server, '/foo')
-        add_route.assert_any_call('GET', '/foo', mock_server.handle_request,
-                                  name=None)
-        add_route.assert_any_call('POST', '/foo', mock_server.handle_request)
+        add_get.assert_any_call('/foo', mock_server.handle_request)
+        add_post.assert_any_call('/foo', mock_server.handle_request)
 
     def test_translate_request(self):
         request = mock.MagicMock()


### PR DESCRIPTION
…se.send_bytes functions to be awaited(coroutines) - do this in a backwards compatible way

A proposed fix for Bug #62. 
