### PR TITLE
fix race condition causing unreliable websocket upgrade

### DIFF
--- a/engineio/asyncio_socket.py
+++ b/engineio/asyncio_socket.py
@@ -119,6 +119,20 @@ class AsyncSocket(socket.Socket):
 
     async def _websocket_handler(self, ws):
         """Engine.IO handler for websocket transport."""
+        # force a polling cycle on the client in short intervals
+        # this is necessary because some clients may block on a long polling request
+        # and while they are blocked they cannot continue the upgrade process
+        # sending a no-op every 100ms ensures that clients wake up and the upgrade is fast
+        # (the same behaviour is also implemented in the javascript engine.io server implementation)
+        async def check_loop():
+            once = False
+            while not once or not check_loop.quit:
+                once = True
+                if self.queue.empty():
+                    await self.send(packet.Packet(packet.NOOP))
+                await self.server.sleep(0.1)
+        check_loop.quit = False
+
         if self.connected:
             # the socket was already connected, so this is an upgrade
             await self.queue.join()  # flush the queue first
@@ -133,9 +147,10 @@ class AsyncSocket(socket.Socket):
             await ws.send(packet.Packet(
                 packet.PONG,
                 data=six.text_type('probe')).encode(always_bytes=False))
-            await self.send(packet.Packet(packet.NOOP))
+            asyncio.ensure_future(check_loop())
 
             pkt = await ws.wait()
+            check_loop.quit = True # we are done with the upgrade process (either success or fail)
             decoded_pkt = packet.Packet(encoded_packet=pkt)
             if decoded_pkt.packet_type != packet.UPGRADE:
                 self.upgraded = False

--- a/tests/test_asyncio_socket.py
+++ b/tests/test_asyncio_socket.py
@@ -59,6 +59,7 @@ class TestSocket(unittest.TestCase):
                               'websocket_class': 'wc'}
         mock_server._async['translate_request'].return_value = 'request'
         mock_server._async['make_response'].return_value = 'response'
+        mock_server.sleep = asyncio.sleep
         mock_server._trigger_event = AsyncMock()
         return mock_server
 

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -41,6 +41,7 @@ class TestSocket(unittest.TestCase):
             return th
 
         mock_server.start_background_task = bg_task
+        mock_server.sleep = time.sleep
         return mock_server
 
     def _join_bg_tasks(self):


### PR DESCRIPTION
Sending a single noop is not enough in all cases, since the client may start a
new polling request right away before doing the websocket upgrade tasks.

Before this fix the socketio javascript client could in some cases block for up
to ping_timeout seconds (not sending or receiving any messages) during upgrade
to websockets. This can be observed in the debug browser console logs from engine.io-client:

```
15:17:42.456 engine.io-client:polling we are currently polling - waiting to pause +1ms browser.js:138
... nothing for 60 seconds ...
15:18:42.247 The connection to ws://localhost:5000/ was interrupted while the page was loading. websocket.js:117
```

The fix is to periodically send noops if the queue is empty so that no polling
request blocks for a long time during upgrade.