### PR TITLE
Fix file descriptor leakage

### DIFF
--- a/engineio/socket.py
+++ b/engineio/socket.py
@@ -232,6 +232,6 @@ class Socket(object):
 
         self.queue.put(None)  # unlock the writer task so that it can exit
         writer_task.join()
-        self.close(wait=True, abort=True)
+        self.close(wait=False, abort=True)
 
         return []


### PR DESCRIPTION
Do not wait for the queue to be emptied when the writer thread is terminated.
As the writer thread is no longer active, the queue will never be emptied. This should fix https://github.com/miguelgrinberg/python-engineio/issues/56