### PR TITLE
Fix socket leakage

### DIFF
--- a/engineio/socket.py
+++ b/engineio/socket.py
@@ -127,6 +127,7 @@ class Socket(object):
             self.closed = True
             if wait:
                 self.queue.join()
+            del self.server.sockets[self.sid]
 
     def _upgrade_websocket(self, environ, start_response):
         """Upgrade the connection from polling to websocket."""


### PR DESCRIPTION
Remove the socket from the server sockets set when it gets closed. Otherwise it will be never removed and
file descriptors are leaked.