### PR TITLE
Prevent side effect in test_async_modes_wsgi (fixes #89)

### DIFF
--- a/tests/asyncio/test_asyncio_server.py
+++ b/tests/asyncio/test_asyncio_server.py
@@ -115,6 +115,7 @@ class TestAsyncServer(unittest.TestCase):
                           async_mode='gevent_uwsgi')
         self.assertRaises(ValueError, asyncio_server.AsyncServer,
                           async_mode='threading')
+        sys.modules.pop('engineio.async_drivers.gevent')
 
     @mock.patch('importlib.import_module')
     def test_attach(self, import_module):

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps=
     urllib3
     websocket-client
     websockets
+    gevent
 basepython =
     flake8: python3.5
     py27: python2.7


### PR DESCRIPTION
The gevent driver was successfully imported here when trying to test async_mode='gevent'. This makes the later mock in test_async_mode_gevent (in test_server.py) fails to actually patch the gevent modules. Removing the imported gevent driver from sys.modules fixes the side effect.