### PR TITLE
Set cookies to websocket connection

### DIFF
--- a/engineio/asyncio_client.py
+++ b/engineio/asyncio_client.py
@@ -202,6 +202,9 @@ class AsyncClient(client.Client):
             await self._receive_packet(pkt)
 
         if 'websocket' in self.upgrades and 'websocket' in self.transports:
+            # apply cookies to websocket connection's headers
+            headers['Cookie'] = r.getheaders().get('Set-Cookie')
+
             # attempt to upgrade to websocket
             if await self._connect_websocket(url, headers, engineio_path):
                 # upgrade to websocket succeeded, we're done here

--- a/engineio/client.py
+++ b/engineio/client.py
@@ -298,6 +298,9 @@ class Client(object):
             self._receive_packet(pkt)
 
         if 'websocket' in self.upgrades and 'websocket' in self.transports:
+            # apply cookies to websocket connection's headers
+            headers['Cookie'] = r.getheaders().get('Set-Cookie')
+
             # attempt to upgrade to websocket
             if self._connect_websocket(url, headers, engineio_path):
                 # upgrade to websocket succeeded, we're done here


### PR DESCRIPTION
Hi Miguel,

I am testing https://github.com/miguelgrinberg/python-socketio, it's working well so far but I encountered issues in a production environment.

Particularly when there is a load balancer on top of socket.io server.

To handle websockets, load balancers usually set a cookie in order to keep the client sticky.
Unfortunately cookies are not handled in `python-engineio`, hence this PR.

**Here is a schema to illustrate the issue:**

![cookie-engineio](https://user-images.githubusercontent.com/16418264/51744325-c0ea9a00-209f-11e9-9d4d-5dff631590e0.png)

Regarding the fix, all cookies present are forwarded. Another approach could be to have a cookie property in `Client` class, like it's done on server side (https://github.com/miguelgrinberg/python-engineio/blob/master/engineio/server.py#L484) to only take care of one cookie.

**Some readings about the problem:**

https://deepstreamhub.com/blog/load-balancing-websocket-connections/
https://socket.io/docs/using-multiple-nodes/
https://www.haproxy.com/blog/websockets-load-balancing-with-haproxy/