### PR TITLE
Fix hang on KeyboardInterrupt when running with asyncio.

### DIFF
--- a/engineio/asyncio_server.py
+++ b/engineio/asyncio_server.py
@@ -415,6 +415,9 @@ class AsyncServer(server.Server):
                     if not socket.closing and not socket.closed:
                         await socket.check_ping_timeout()
                     await self.sleep(sleep_interval)
+            except asyncio.CancelledError:
+                self.logger.debug('service task cancelled')
+                break
             except:
                 # an unexpected exception has occurred, log it and continue
                 self.logger.exception('service task exception')

--- a/engineio/asyncio_server.py
+++ b/engineio/asyncio_server.py
@@ -415,7 +415,7 @@ class AsyncServer(server.Server):
                     if not socket.closing and not socket.closed:
                         await socket.check_ping_timeout()
                     await self.sleep(sleep_interval)
-            except asyncio.CancelledError:
+            except (KeyboardInterrupt, asyncio.CancelledError):
                 self.logger.debug('service task cancelled')
                 break
             except:


### PR DESCRIPTION
The bare except in the _service_task function also catches and
ignores asyncio.CancelledError exceptions. This means the function
will never gracefully exit when cancelling the task.

The solution I propose here adds an additional except handler
specifically for asyncio.CancelledError which will then stop the
service task.

This allows f.e. aiohttp to cancel all pending tasks and allows
the process to terminate even when there are connected clients.

This most likely fixes https://github.com/miguelgrinberg/python-socketio/issues/230