### PR TITLE
Pass cookies at websocket connection creation

### DIFF
--- a/engineio/client.py
+++ b/engineio/client.py
@@ -329,8 +329,11 @@ class Client(object):
             self.logger.info(
                 'Attempting WebSocket connection to ' + websocket_url)
         try:
+            cookies = None
+            if self.http:
+                cookies = '; '.join(["{}={}".format(x.name, x.value) for x in self.http.cookies])
             ws = websocket.create_connection(
-                websocket_url + self._get_url_timestamp(), header=headers)
+                websocket_url + self._get_url_timestamp(), header=headers, cookie=cookies)
         except ConnectionError:
             if upgrade:
                 self.logger.warning(

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -488,7 +488,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(c.upgrades, [])
         self.assertEqual(c.transport(), 'websocket')
         self.assertEqual(c.ws, create_connection.return_value)
-        create_connection.assert_called_once()
+        self.assertEqual(len(create_connection.call_args_list), 1)
         url = create_connection.call_args[0][0]
         create_connection.assert_called_once_with(
             url, header={}, cookie=None)
@@ -515,7 +515,7 @@ class TestClient(unittest.TestCase):
         c.connect('ws://foo', transports=['websocket'])
         time.sleep(0.1)
 
-        create_connection.assert_called_once()
+        self.assertEqual(len(create_connection.call_args_list), 1)
         url = create_connection.call_args[0][0]
         create_connection.assert_called_once_with(
             url, header={}, cookie="key=value; key2=value2")


### PR DESCRIPTION
This follows https://github.com/miguelgrinberg/python-engineio/pull/93

Switching `urllib3` to `requests` was a right move but there is still an uncovered case.
Indeed cookies are stored in `Session` object so are well handled for long polling for example, but they are not passed when websocket connection is created.

Implementation:
- Get cookie from `requests.Session()`
- Pass those cookies to `cookie` parameter of `create_connection` and `connect` methods of `websocket` class

