### PR TITLE
Downgrade log levels in some areas

### DIFF
--- a/engineio/asyncio_client.py
+++ b/engineio/asyncio_client.py
@@ -400,7 +400,7 @@ class AsyncClient(client.Client):
         self.ping_loop_event.clear()
         while self.state == 'connected':
             if not self.pong_received:
-                self.logger.warning(
+                self.logger.info(
                     'PONG response has not been received, aborting')
                 if self.ws:
                     await self.ws.close()
@@ -464,7 +464,7 @@ class AsyncClient(client.Client):
             try:
                 p = await self.ws.recv()
             except websockets.exceptions.ConnectionClosed:
-                self.logger.warning(
+                self.logger.info(
                     'Read loop: WebSocket connection was closed, aborting')
                 await self.queue.put(None)
                 break
@@ -548,7 +548,7 @@ class AsyncClient(client.Client):
                         await self.ws.send(pkt.encode(always_bytes=False))
                         self.queue.task_done()
                 except websockets.exceptions.ConnectionClosed:
-                    self.logger.warning(
+                    self.logger.info(
                         'Write loop: WebSocket connection was closed, '
                         'aborting')
                     break

--- a/engineio/client.py
+++ b/engineio/client.py
@@ -488,7 +488,7 @@ class Client(object):
         self.ping_loop_event.clear()
         while self.state == 'connected':
             if not self.pong_received:
-                self.logger.warning(
+                self.logger.info(
                     'PONG response has not been received, aborting')
                 if self.ws:
                     self.ws.close()


### PR DESCRIPTION
This PR reduces the log level of several logging statements during unexpected socket disconnection and reconnection (since the end-user impact is low-to-none).

Fixes https://github.com/miguelgrinberg/python-engineio/issues/102.