### PR TITLE
Support for Tornado 6

### DIFF
--- a/engineio/async_drivers/tornado.py
+++ b/engineio/async_drivers/tornado.py
@@ -27,7 +27,7 @@ def get_tornado_handler(engineio_server):
 
         async def get(self, *args, **kwargs):
             if self.request.headers.get('Upgrade', '').lower() == 'websocket':
-                super().get(*args, **kwargs)
+                await super().get(*args, **kwargs)
             await engineio_server.handle_request(self)
 
         async def post(self, *args, **kwargs):

--- a/engineio/async_drivers/tornado.py
+++ b/engineio/async_drivers/tornado.py
@@ -130,7 +130,7 @@ def make_response(status, headers, payload, environ):
         tornado_handler.write(payload)
         tornado_handler.finish()
     except RuntimeError as error:
-        if not "Method not supported for Web Sockets" in str(error):
+        if "Method not supported for Web Sockets" not in str(error):
             raise
 
 

--- a/engineio/async_drivers/tornado.py
+++ b/engineio/async_drivers/tornado.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 from urllib.parse import urlsplit
+from .. import exceptions
 
 try:
     import tornado.web
@@ -152,8 +153,11 @@ class WebSocket(object):  # pragma: no cover
         self.tornado_handler.close()
 
     async def send(self, message):
-        self.tornado_handler.write_message(
-            message, binary=isinstance(message, bytes))
+        try:
+            self.tornado_handler.write_message(
+                message, binary=isinstance(message, bytes))
+        except tornado.websocket.WebSocketClosedError:
+            raise exceptions.EngineIOError()
 
     async def wait(self):
         msg = await self.tornado_handler.get_next_message()

--- a/engineio/asyncio_server.py
+++ b/engineio/asyncio_server.py
@@ -215,6 +215,13 @@ class AsyncServer(server.Server):
                             if sid in self.sockets:  # pragma: no cover
                                 await self.disconnect(sid)
                             r = self._bad_request()
+                        except Exception as error:
+                            if "WebSocketClosedError" in str(type(error)):
+                                if sid in self.sockets:  # pragma: no cover
+                                    await self.disconnect(sid)
+                                r = self._bad_request()
+                            else:
+                                raise
                         if sid in self.sockets and self.sockets[sid].closed:
                             del self.sockets[sid]
             elif method == 'POST':

--- a/engineio/asyncio_server.py
+++ b/engineio/asyncio_server.py
@@ -215,13 +215,6 @@ class AsyncServer(server.Server):
                             if sid in self.sockets:  # pragma: no cover
                                 await self.disconnect(sid)
                             r = self._bad_request()
-                        except Exception as error:
-                            if "WebSocketClosedError" in str(type(error)):
-                                if sid in self.sockets:  # pragma: no cover
-                                    await self.disconnect(sid)
-                                r = self._bad_request()
-                            else:
-                                raise
                         if sid in self.sockets and self.sockets[sid].closed:
                             del self.sockets[sid]
             elif method == 'POST':


### PR DESCRIPTION
Hello!

I was working with the library python-socketio and by a problem with the connect I updated it to the latest version (and tornado too) and the following error appears:

```
site-packages/engineio/async_drivers/tornado.py:30: RuntimeWarning: coroutine 'WebSocketHandler.get' was never awaited
  super().get(*args, **kwargs)
```

It happens with Tornado version 6< and block part of the library. And at least in my user-case, only adding `await` in that line the issue was fixed, so I submit this pull request to help with compatibility issues.