### PR TITLE
Fix to reconnection thread not spawned when socket disconnected unexpectly

### DIFF
--- a/engineio/client.py
+++ b/engineio/client.py
@@ -591,7 +591,6 @@ class Client(object):
                 packets = [self.queue.get(timeout=timeout)]
             except self.queue.Empty:
                 self.logger.error('packet queue is empty, aborting')
-                self._reset()
                 break
             if packets == [None]:
                 self.queue.task_done()


### PR DESCRIPTION
This will fix the socket not being able to reconnect when there was a communication problem (such as bad internet connection or the server delaying the response). 

The reset will be done after calling the disconnected event. 

It will solve #110 and miguelgrinberg/python-socketio#305



