### PR TITLE
Remove tests from production code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email='miguelgrinberg50@gmail.com',
     description='Engine.IO server',
     long_description=long_description,
-    packages=find_packages(),
+    packages=["engineio"],
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
Remove find_packages and add engineio packages
    
...to prevent the tests to be included in production code.
    
From "Using find_packages()":
>     For simple projects, it’s usually easy enough to manually add
>     packages to the packages argument of setup(). However, for very
>     large projects (Twisted, PEAK, Zope, Chandler, etc.), it can be a
>     big burden to keep the package list updated. That’s what
>     setuptools.find_packages() is for.

Read:
https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages

Resolves #123