### PR TITLE
implement ping and pong events

### DIFF
--- a/engineio/asyncio_client.py
+++ b/engineio/asyncio_client.py
@@ -136,9 +136,8 @@ class AsyncClient(client.Client):
         :param args: arguments to pass to the function.
         :param kwargs: keyword arguments to pass to the function.
 
-        This function returns an object compatible with the `Thread` class in
-        the Python standard library. The `start()` method on this object is
-        already called by this function.
+        This function returns Future object or Task object wrapped
+        around target function.
 
         Note: this method is a coroutine.
         """
@@ -333,6 +332,7 @@ class AsyncClient(client.Client):
             await self._trigger_event('message', pkt.data, run_async=True)
         elif pkt.packet_type == packet.PONG:
             self.pong_received = True
+            await self._trigger_event('pong', run_async=True)
         elif pkt.packet_type == packet.CLOSE:
             await self.disconnect(abort=True)
         elif pkt.packet_type == packet.NOOP:
@@ -428,6 +428,7 @@ class AsyncClient(client.Client):
                 break
             self.pong_received = False
             await self._send_packet(packet.Packet(packet.PING))
+            await self._trigger_event("ping", run_async=True)
             try:
                 await asyncio.wait_for(self.ping_loop_event.wait(),
                                        self.ping_interval)

--- a/engineio/client.py
+++ b/engineio/client.py
@@ -69,7 +69,7 @@ class Client(object):
                        connections to servers with self signed certificates.
                        The default is ``True``.
     """
-    event_names = ['connect', 'disconnect', 'message']
+    event_names = ['connect', 'disconnect', 'message', 'ping', 'pong']
 
     def __init__(self,
                  logger=False,
@@ -447,6 +447,7 @@ class Client(object):
             self._trigger_event('message', pkt.data, run_async=True)
         elif pkt.packet_type == packet.PONG:
             self.pong_received = True
+            self._trigger_event('pong', run_async=True)
         elif pkt.packet_type == packet.CLOSE:
             self.disconnect(abort=True)
         elif pkt.packet_type == packet.NOOP:
@@ -533,6 +534,7 @@ class Client(object):
                 break
             self.pong_received = False
             self._send_packet(packet.Packet(packet.PING))
+            self._trigger_event("ping", run_async=True)
             self.ping_loop_event.wait(timeout=self.ping_interval)
         self.logger.info('Exiting ping task')
 

--- a/tests/asyncio/test_asyncio_client.py
+++ b/tests/asyncio/test_asyncio_client.py
@@ -841,6 +841,7 @@ class TestAsyncClient(unittest.TestCase):
         @c.on('ping')
         def ping():
             return True
+
         async def fake_wait():
             c.state, c.pong_received = states.pop(0)
         c.ping_loop_event.wait = fake_wait
@@ -850,6 +851,7 @@ class TestAsyncClient(unittest.TestCase):
         c._receive_packet = AsyncMock()
         _run(c._read_loop_websocket())
         c._trigger_event.mock.assert_called_once_with('ping', run_async=True)
+
     def test_trigger_unknown_event(self):
         c = asyncio_client.AsyncClient()
         _run(c._trigger_event('connect', run_async=False))

--- a/tests/asyncio/test_asyncio_client.py
+++ b/tests/asyncio/test_asyncio_client.py
@@ -844,6 +844,7 @@ class TestAsyncClient(unittest.TestCase):
 
         async def fake_wait():
             c.state, c.pong_received = states.pop(0)
+        c.ping_loop_event = c.create_event()
         c.ping_loop_event.wait = fake_wait
         _run(c._ping_loop())
         c.write_loop_task = AsyncMock()()

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -750,7 +750,6 @@ class TestClient(unittest.TestCase):
         c.state = 'connected'
         c.queue = mock.MagicMock()
         c._trigger_event = mock.MagicMock()
-        c._trigger_event = mock.MagicMock()
         states = [
             ('disconnecting', True)
         ]

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -761,6 +761,7 @@ class TestClient(unittest.TestCase):
         def fake_wait(timeout):
             c.state, c.pong_received = states.pop(0)
 
+        c.ping_loop_event = c.create_event()
         c.ping_loop_event.wait = fake_wait
         c._ping_loop()
         c.write_loop_task = mock.MagicMock()


### PR DESCRIPTION
Those events are firing in the same places as specified here: 
https://github.com/socketio/engine.io-client#events

I think it is relevant to have these events handled in this project too, not only because implementations in other languages have them but also I found them usefull for implementing custom disconnect handling. (Sometimes I'm in situation where server didn't send close packet, the connection seems to be fine but the ping pong exchange has stopped).