### PR TITLE
Unreasonable logic for ping timeout

### DIFF
--- a/engineio/asyncio_socket.py
+++ b/engineio/asyncio_socket.py
@@ -54,7 +54,7 @@ class AsyncSocket(socket.Socket):
         """
         if self.closed:
             raise exceptions.SocketIsClosedError()
-        if time.time() - self.last_ping > self.server.ping_interval + 5:
+        if time.time() - self.last_ping > self.server.ping_interval * 2:
             self.server.logger.info('%s: Client is gone, closing socket',
                                     self.sid)
             # Passing abort=False here will cause close() to write a

--- a/engineio/socket.py
+++ b/engineio/socket.py
@@ -70,7 +70,7 @@ class Socket(object):
         """
         if self.closed:
             raise exceptions.SocketIsClosedError()
-        if time.time() - self.last_ping > self.server.ping_interval + 5:
+        if time.time() - self.last_ping > self.server.ping_interval * 2:
             self.server.logger.info('%s: Client is gone, closing socket',
                                     self.sid)
             # Passing abort=False here will cause close() to write a


### PR DESCRIPTION
In the author's source code, the logic for the client to send a ping request to the server is mainly in the _ping_loop method of client.py[line:493] and asyncio_client.py[line:405].

The core logic of this method is to wait for ping_interval seconds asynchronously after sending a ping request. In the meantime, it will theoretically receive the pong returned by the server. If it is not received, disconnect ws, otherwise continue the above loop. That is, every two ping requests are roughly separated by ping_interval seconds.

After the nth ping request is sent, the pong of the server response is received in a very short time, and the n+1 th ping request is sent after ping_interval seconds. If the network fluctuates, the server receives the request after (ping_interval - 2) seconds and respond immediately. The response was received by the client in a very short time and is still in ping_interval seconds. For the client, the connection is normal and does not need to be disconnected.

But for the server, last_ping is the last time the ping request was received. After receiving the ping request again, it has passed (ping_interval + ping_interval - 2) seconds, far exceeding the preset (ping_interval + 5) seconds, so the server will not hesitate to disconnect the link.

In some cross-border connections, the frequency of this phenomenon is not uncommon, but it is actually unreasonable.

For the client, the extreme case of staying connected is the (ping_interval + ping_interval) seconds between the first ping request and the second pong response.

For the server, the mysterious parameters of 5 seconds have no theoretical basis. Conversely, if the second ping request is not received after (ping_interval + ping_interval) seconds, then it is certain that the client disconnected and the server should be disconnected.

Thank you for your acceptance.