### PR TITLE
SSL certificate trusting by adding a 'cert' parameter to client connections

### DIFF
--- a/engineio/asyncio_client.py
+++ b/engineio/asyncio_client.py
@@ -213,7 +213,8 @@ class AsyncClient(client.Client):
 
         if 'websocket' in self.upgrades and 'websocket' in self.transports:
             # attempt to upgrade to websocket
-            if await self._connect_websocket(url, headers, engineio_path, cert):
+            if await self._connect_websocket(url, headers, engineio_path,
+                                             cert):
                 # upgrade to websocket succeeded, we're done here
                 return
 

--- a/engineio/client.py
+++ b/engineio/client.py
@@ -341,7 +341,7 @@ class Client(object):
         if self.http:
             cookies = '; '.join(["{}={}".format(cookie.name, cookie.value)
                                  for cookie in self.http.cookies])
-        sslopt = {'certfile' : cert}
+        sslopt = {'certfile': cert}
         try:
             ws = websocket.create_connection(
                 websocket_url + self._get_url_timestamp(), header=headers,

--- a/tests/asyncio/test_asyncio_client.py
+++ b/tests/asyncio/test_asyncio_client.py
@@ -68,14 +68,14 @@ class TestAsyncClient(unittest.TestCase):
         c._connect_polling = AsyncMock(return_value='foo')
         self.assertEqual(_run(c.connect('http://foo')), 'foo')
         c._connect_polling.mock.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
         c = asyncio_client.AsyncClient()
         c._connect_polling = AsyncMock(return_value='foo')
         self.assertEqual(
             _run(c.connect('http://foo', transports=['polling'])), 'foo')
         c._connect_polling.mock.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
         c = asyncio_client.AsyncClient()
         c._connect_polling = AsyncMock(return_value='foo')
@@ -84,7 +84,7 @@ class TestAsyncClient(unittest.TestCase):
                                                      'websocket'])),
             'foo')
         c._connect_polling.mock.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
     def test_connect_websocket(self):
         c = asyncio_client.AsyncClient()
@@ -93,7 +93,7 @@ class TestAsyncClient(unittest.TestCase):
             _run(c.connect('http://foo', transports=['websocket'])),
             'foo')
         c._connect_websocket.mock.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
         c = asyncio_client.AsyncClient()
         c._connect_websocket = AsyncMock(return_value='foo')
@@ -101,14 +101,14 @@ class TestAsyncClient(unittest.TestCase):
             _run(c.connect('http://foo', transports='websocket')),
             'foo')
         c._connect_websocket.mock.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
     def test_connect_query_string(self):
         c = asyncio_client.AsyncClient()
         c._connect_polling = AsyncMock(return_value='foo')
         self.assertEqual(_run(c.connect('http://foo?bar=baz')), 'foo')
         c._connect_polling.mock.assert_called_once_with(
-            'http://foo?bar=baz', {}, 'engine.io')
+            'http://foo?bar=baz', {}, 'engine.io', None)
 
     def test_connect_custom_headers(self):
         c = asyncio_client.AsyncClient()
@@ -117,7 +117,7 @@ class TestAsyncClient(unittest.TestCase):
             _run(c.connect('http://foo', headers={'Foo': 'Bar'})),
             'foo')
         c._connect_polling.mock.assert_called_once_with(
-            'http://foo', {'Foo': 'Bar'}, 'engine.io')
+            'http://foo', {'Foo': 'Bar'}, 'engine.io', None)
 
     def test_wait(self):
         c = asyncio_client.AsyncClient()
@@ -270,7 +270,7 @@ class TestAsyncClient(unittest.TestCase):
                 'http://foo', headers={'Foo': 'Bar'}))
         c._send_request.mock.assert_called_once_with(
             'GET', 'http://foo/engine.io/?transport=polling&EIO=3&t=123.456',
-            headers={'Foo': 'Bar'}, timeout=5)
+            cert=None, headers={'Foo': 'Bar'}, timeout=5)
 
     def test_polling_connection_404(self):
         c = asyncio_client.AsyncClient()
@@ -380,7 +380,7 @@ class TestAsyncClient(unittest.TestCase):
         _run(c.connect('http://foo'))
 
         c._connect_websocket.mock.assert_called_once_with('http://foo', {},
-                                                          'engine.io')
+                                                          'engine.io', None)
         on_connect.assert_called_once_with()
         self.assertIn(c, client.connected_clients)
         self.assertEqual(
@@ -413,7 +413,7 @@ class TestAsyncClient(unittest.TestCase):
         time.sleep(0.1)
 
         c._connect_websocket.mock.assert_called_once_with('http://foo', {},
-                                                          'engine.io')
+                                                          'engine.io', None)
         c._ping_loop.mock.assert_called_once_with()
         c._read_loop_polling.mock.assert_called_once_with()
         c._read_loop_websocket.mock.assert_not_called()
@@ -432,7 +432,7 @@ class TestAsyncClient(unittest.TestCase):
                       headers={'Foo': 'Bar'}))
         asyncio_client.websockets.connect.mock.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=3&t=123.456',
-            extra_headers={'Foo': 'Bar'})
+            extra_headers={'Foo': 'Bar'}, sslopt={'certfile': None})
 
     @mock.patch('engineio.client.time.time', return_value=123.456)
     @mock.patch('engineio.asyncio_client.websockets.connect', new=AsyncMock(
@@ -444,7 +444,7 @@ class TestAsyncClient(unittest.TestCase):
             'http://foo', transports=['websocket'])))
         asyncio_client.websockets.connect.mock.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=3&sid=123&t=123.456',
-            extra_headers={})
+            extra_headers={}, sslopt={'certfile': None})
 
     @mock.patch('engineio.asyncio_client.websockets.connect', new=AsyncMock())
     def test_websocket_connection_no_open_packet(self):
@@ -491,7 +491,7 @@ class TestAsyncClient(unittest.TestCase):
         self.assertEqual(c.ws, ws)
         asyncio_client.websockets.connect.mock.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=3&t=123.456',
-            extra_headers={})
+            extra_headers={}, sslopt={'certfile': None})
 
     @mock.patch('engineio.client.time.time', return_value=123.456)
     @mock.patch('engineio.asyncio_client.websockets.connect', new=AsyncMock())
@@ -519,7 +519,8 @@ class TestAsyncClient(unittest.TestCase):
         time.sleep(0.1)
         asyncio_client.websockets.connect.mock.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=3&t=123.456',
-            extra_headers={'Cookie': 'key=value; key2=value2'})
+            extra_headers={'Cookie': 'key=value; key2=value2'},
+            sslopt={'certfile': None})
 
     @mock.patch('engineio.asyncio_client.websockets.connect', new=AsyncMock())
     def test_websocket_upgrade_no_pong(self):

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -97,14 +97,14 @@ class TestClient(unittest.TestCase):
         c._connect_polling = mock.MagicMock(return_value='foo')
         self.assertEqual(c.connect('http://foo'), 'foo')
         c._connect_polling.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
         c = client.Client()
         c._connect_polling = mock.MagicMock(return_value='foo')
         self.assertEqual(c.connect('http://foo', transports=['polling']),
                          'foo')
         c._connect_polling.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
         c = client.Client()
         c._connect_polling = mock.MagicMock(return_value='foo')
@@ -112,7 +112,7 @@ class TestClient(unittest.TestCase):
                                    transports=['polling', 'websocket']),
                          'foo')
         c._connect_polling.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
     def test_connect_websocket(self):
         c = client.Client()
@@ -120,21 +120,21 @@ class TestClient(unittest.TestCase):
         self.assertEqual(c.connect('http://foo', transports=['websocket']),
                          'foo')
         c._connect_websocket.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
         c = client.Client()
         c._connect_websocket = mock.MagicMock(return_value='foo')
         self.assertEqual(c.connect('http://foo', transports='websocket'),
                          'foo')
         c._connect_websocket.assert_called_once_with(
-            'http://foo', {}, 'engine.io')
+            'http://foo', {}, 'engine.io', None)
 
     def test_connect_query_string(self):
         c = client.Client()
         c._connect_polling = mock.MagicMock(return_value='foo')
         self.assertEqual(c.connect('http://foo?bar=baz'), 'foo')
         c._connect_polling.assert_called_once_with(
-            'http://foo?bar=baz', {}, 'engine.io')
+            'http://foo?bar=baz', {}, 'engine.io', None)
 
     def test_connect_custom_headers(self):
         c = client.Client()
@@ -142,7 +142,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(c.connect('http://foo', headers={'Foo': 'Bar'}),
                          'foo')
         c._connect_polling.assert_called_once_with(
-            'http://foo', {'Foo': 'Bar'}, 'engine.io')
+            'http://foo', {'Foo': 'Bar'}, 'engine.io', None)
 
     def test_wait(self):
         c = client.Client()
@@ -288,7 +288,7 @@ class TestClient(unittest.TestCase):
                           headers={'Foo': 'Bar'})
         _send_request.assert_called_once_with(
             'GET', 'http://foo/engine.io/?transport=polling&EIO=3&t=123.456',
-            headers={'Foo': 'Bar'}, timeout=5)
+            cert=None, headers={'Foo': 'Bar'}, timeout=5)
 
     @mock.patch('engineio.client.Client._send_request')
     def test_polling_connection_404(self, _send_request):
@@ -390,7 +390,7 @@ class TestClient(unittest.TestCase):
         c.connect('http://foo')
 
         c._connect_websocket.assert_called_once_with('http://foo', {},
-                                                     'engine.io')
+                                                     'engine.io', None)
         on_connect.assert_called_once_with()
         self.assertIn(c, client.connected_clients)
         self.assertEqual(
@@ -422,7 +422,7 @@ class TestClient(unittest.TestCase):
         time.sleep(0.1)
 
         c._connect_websocket.assert_called_once_with('http://foo', {},
-                                                     'engine.io')
+                                                     'engine.io', None)
         c._ping_loop.assert_called_once_with()
         c._read_loop_polling.assert_called_once_with()
         c._read_loop_websocket.assert_not_called()
@@ -439,7 +439,7 @@ class TestClient(unittest.TestCase):
                           transports=['websocket'], headers={'Foo': 'Bar'})
         create_connection.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=3&t=123.456',
-            header={'Foo': 'Bar'}, cookie=None)
+            header={'Foo': 'Bar'}, cookie=None, sslopt={'certfile': None})
 
     @mock.patch('engineio.client.time.time', return_value=123.456)
     @mock.patch('engineio.client.websocket.create_connection',
@@ -450,7 +450,7 @@ class TestClient(unittest.TestCase):
         self.assertFalse(c.connect('http://foo', transports=['websocket']))
         create_connection.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=3&sid=123&t=123.456',
-            header={}, cookie=None)
+            header={}, cookie=None, sslopt={'certfile': None})
 
     @mock.patch('engineio.client.websocket.create_connection')
     def test_websocket_connection_no_open_packet(self, create_connection):
@@ -494,7 +494,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(c.ws, create_connection.return_value)
         self.assertEqual(len(create_connection.call_args_list), 1)
         self.assertEqual(create_connection.call_args[1],
-                         {'header': {}, 'cookie': None})
+                         {'header': {}, 'cookie': None,
+                          'sslopt': {'certfile': None}})
 
     @mock.patch('engineio.client.websocket.create_connection')
     def test_websocket_connection_with_cookies(self, create_connection):
@@ -521,7 +522,8 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(len(create_connection.call_args_list), 1)
         self.assertEqual(create_connection.call_args[1],
-                         {'header': {}, 'cookie': 'key=value; key2=value2'})
+                         {'header': {}, 'cookie': 'key=value; key2=value2',
+                          'sslopt': {'certfile': None}})
 
     @mock.patch('engineio.client.websocket.create_connection')
     def test_websocket_upgrade_no_pong(self, create_connection):


### PR DESCRIPTION
This allows for the explicit and programmatic trusting of an SSL certificate at connection time. This is important if you're using SSL certificates that are not provided by a widely trusted authority and you want to avoid environment manipulation. Examples could be testing environments or servers that generate their own certificates at run-time.