### PR TITLE
avoid loop without yield when count of sockets is too high

### DIFF
--- a/engineio/server.py
+++ b/engineio/server.py
@@ -652,7 +652,7 @@ class Server(object):
                 continue
 
             # go through the entire client list in a ping interval cycle
-            sleep_interval = self.ping_timeout / len(self.sockets)
+            sleep_interval = float(self.ping_timeout) / len(self.sockets)
 
             try:
                 # iterate over the current clients


### PR DESCRIPTION
For Python 2.x, `sleep_interval` is 0 if `len(self.sockets)` is above
`self.ping_timeout` (default: 60). With eventlet, `self.sleep(0)` looks it does not
yield to the event loop, queueing work which is not processed.  In this
condition, the symptom is the server using 100% of CPU after some time, even
when count of sockets drop below `len(self.sockets)`.

This fix forces `sleep_interval` to be a float, not equal to 0, forcing eventlet
to yield, processing the queued work and avoiding CPU to be at 100%.

This fix does nothing for Python 3.x.