### PR TITLE
No sigint handler

### DIFF
--- a/engineio/client.py
+++ b/engineio/client.py
@@ -43,7 +43,7 @@ def signal_handler(sig, frame):
         return original_signal_handler(sig, frame)
     else:
         # Handle case where no original SIGINT handler was present.
-        return signal.def_int_handler(sig, frame)
+        return signal.default_int_handler(sig, frame)
 
 
 original_signal_handler = signal.signal(signal.SIGINT, signal_handler)

--- a/engineio/client.py
+++ b/engineio/client.py
@@ -39,7 +39,11 @@ def signal_handler(sig, frame):
             client.start_background_task(client.disconnect, abort=True)
         else:
             client.disconnect(abort=True)
-    return original_signal_handler(sig, frame)
+    if callable(original_signal_handler):
+        return original_signal_handler(sig, frame)
+    else:
+        # Handle case where no original SIGINT handler was present.
+        return signal.def_int_handler( sig, frame)
 
 
 original_signal_handler = signal.signal(signal.SIGINT, signal_handler)

--- a/engineio/client.py
+++ b/engineio/client.py
@@ -43,7 +43,7 @@ def signal_handler(sig, frame):
         return original_signal_handler(sig, frame)
     else:
         # Handle case where no original SIGINT handler was present.
-        return signal.def_int_handler( sig, frame)
+        return signal.def_int_handler(sig, frame)
 
 
 original_signal_handler = signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
The fix I gave you had the wrong name for signal.default_signal_handler. This fixes that. (I just installed python-engineio 3.10 and found the error. I must have checked in the wrong version of my code, not what I tested.