### PR TITLE
Fix AIO server disconnect bug

### DIFF
--- a/engineio/asyncio_server.py
+++ b/engineio/asyncio_server.py
@@ -168,7 +168,8 @@ class AsyncServer(server.Server):
                 pass
             else:
                 await socket.close()
-                del self.sockets[sid]
+                if sid in self.sockets:  # may have removed itself during close
+                    del self.sockets[sid]
         else:
             await asyncio.wait([client.close()
                                 for client in six.itervalues(self.sockets)])


### PR DESCRIPTION
This is in reference to [socketio#366](https://github.com/miguelgrinberg/python-socketio/issues/366).

When the server tries to disconnect the socket it awaits for the queue to finish, and in the process of sending those packets the socket detects it's being closed and deletes itself from the sockets dict. This seems to happen unless there is a socket timeout or another weird disconnect.