### PR TITLE
Fix websocket exception handling on python2.7

### DIFF
--- a/engineio/client.py
+++ b/engineio/client.py
@@ -364,7 +364,7 @@ class Client(object):
                 ws = websocket.create_connection(
                     websocket_url + self._get_url_timestamp(), header=headers,
                     cookie=cookies)
-        except ConnectionError:
+        except (ConnectionError, IOError):
             if upgrade:
                 self.logger.warning(
                     'WebSocket upgrade failed: connection error')


### PR DESCRIPTION
### Problem
This library doesn't handle `socket.error` gracefully in Python 2.7. This becomes much more obvious when you use the `python-socketio` client.

If there's a socketio server running initially, the Python 2.7 client connects and does whatever it does. But if the socketio server dies for some reason, the thread that attempts to reconnect fails due to the unhandled exception because the server rejects connections, and reconnection doesn't work even when the socketio server goes back up.

### Reason
The underlying `websocket` library used here throws a `socket.error` in Python 2.7 when the connection is refused (i.e. when the port is closed). `socket.error` is an `IOError`.

In Python 3.3 onwards, it throws a `ConnectionError` which it catches correctly.

### The Fix

I caught `IOError` here to handle the cases similarly in Python 2.7 and Python 3.x

I'd be happy to add the following alternative to catch less errors, but the PR as is catches a wider net of error conditions that I may not have considered.

```
import socket

...

except (ConnectionError, socket.error):
```
