### PR TITLE
silently removing sid from self.sockets

### DIFF
--- a/engineio/asyncio_server.py
+++ b/engineio/asyncio_server.py
@@ -168,8 +168,7 @@ class AsyncServer(server.Server):
                 pass
             else:
                 await socket.close()
-                if sid in self.sockets:  # pragma: no cover
-                    del self.sockets[sid]
+                self.sockets.pop(sid, None)
         else:
             await asyncio.wait([client.close()
                                 for client in six.itervalues(self.sockets)])
@@ -258,7 +257,7 @@ class AsyncServer(server.Server):
                             await self.disconnect(sid)
                         r = self._bad_request()
                     if sid in self.sockets and self.sockets[sid].closed:
-                        del self.sockets[sid]
+                        self.sockets.pop(sid, None)
         elif method == 'POST':
             if sid is None or sid not in self.sockets:
                 self.logger.warning('Invalid session %s', sid)
@@ -384,7 +383,7 @@ class AsyncServer(server.Server):
         ret = await self._trigger_event('connect', sid, environ,
                                         run_async=False)
         if ret is False:
-            del self.sockets[sid]
+            self.sockets.pop(sid, None)
             self.logger.warning('Application rejected connection')
             return self._unauthorized()
 
@@ -392,7 +391,7 @@ class AsyncServer(server.Server):
             ret = await s.handle_get_request(environ)
             if s.closed:
                 # websocket connection ended, so we are done
-                del self.sockets[sid]
+                self.sockets.pop(sid, None)
             return ret
         else:
             s.connected = True

--- a/engineio/server.py
+++ b/engineio/server.py
@@ -289,8 +289,7 @@ class Server(object):
                 pass
             else:
                 socket.close()
-                if sid in self.sockets:  # pragma: no cover
-                    del self.sockets[sid]
+                self.sockets.pop(sid, None)
         else:
             for client in six.itervalues(self.sockets):
                 client.close()
@@ -384,7 +383,7 @@ class Server(object):
                             self.disconnect(sid)
                         r = self._bad_request()
                     if sid in self.sockets and self.sockets[sid].closed:
-                        del self.sockets[sid]
+                        self.sockets.pop(sid, None)
         elif method == 'POST':
             if sid is None or sid not in self.sockets:
                 self.logger.warning('Invalid session %s', sid)
@@ -506,7 +505,7 @@ class Server(object):
 
         ret = self._trigger_event('connect', sid, environ, run_async=False)
         if ret is False:
-            del self.sockets[sid]
+            self.sockets.pop(sid, None)
             self.logger.warning('Application rejected connection')
             return self._unauthorized()
 
@@ -514,7 +513,7 @@ class Server(object):
             ret = s.handle_get_request(environ, start_response)
             if s.closed:
                 # websocket connection ended, so we are done
-                del self.sockets[sid]
+                self.sockets.pop(sid, None)
             return ret
         else:
             s.connected = True
@@ -557,7 +556,7 @@ class Server(object):
         except KeyError:
             raise KeyError('Session not found')
         if s.closed:
-            del self.sockets[sid]
+            self.sockets.pop(sid, None)
             raise KeyError('Session is disconnected')
         return s
 


### PR DESCRIPTION
Fix KeyError on disconnect

```
3dfb247ad8a345608523c0df9b2176f4: Sending packet CLOSE data None
Traceback (most recent call last):
  File "/Users/laibin/.venv/lib/python3.6/site-packages/gevent/pywsgi.py", line 976, in handle_one_response
    self.run_application()
  File "/Users/laibin/.venv/lib/python3.6/site-packages/geventwebsocket/handler.py", line 75, in run_application
    self.run_websocket()
  File "/Users/laibin/.venv/lib/python3.6/site-packages/geventwebsocket/handler.py", line 52, in run_websocket
    list(self.application(self.environ, lambda s, h, e=None: []))
  File "/Users/laibin/.venv/lib/python3.6/site-packages/flask/app.py", line 2463, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/laibin/.venv/lib/python3.6/site-packages/flask_socketio/__init__.py", line 46, in __call__
    start_response)
  File "/Users/laibin/.venv/lib/python3.6/site-packages/engineio/middleware.py", line 60, in __call__
    return self.engineio_app.handle_request(environ, start_response)
  File "/Users/laibin/.venv/lib/python3.6/site-packages/socketio/server.py", line 534, in handle_request
    return self.eio.handle_request(environ, start_response)
  File "/Users/laibin/.venv/lib/python3.6/site-packages/engineio/server.py", line 367, in handle_request
    transport, b64, jsonp_index)
  File "/Users/laibin/.venv/lib/python3.6/site-packages/engineio/server.py", line 517, in _handle_connect
    del self.sockets[sid]
KeyError: '3dfb247ad8a345608523c0df9b2176f4'
2019-12-20T08:13:14Z {'REMOTE_ADDR': '127.0.0.1', 'REMOTE_PORT': '55972', 'HTTP_HOST': '127.0.0.1:5000', (hidden keys: 31)} failed with KeyError
```