### PR TITLE
Do not hang in polling while websocket upgrade is ongoing

### DIFF
--- a/tests/asyncio/test_asyncio_socket.py
+++ b/tests/asyncio/test_asyncio_socket.py
@@ -249,6 +249,11 @@ class TestSocket(unittest.TestCase):
             packet.PONG, data=probe).encode(always_bytes=False))
         self.assertEqual(_run(s.queue.get()).packet_type, packet.NOOP)
         self.assertFalse(s.upgraded)
+        self.assertTrue(s.poll_ended)
+        environ = {'REQUEST_METHOD': 'GET', 'QUERY_STRING': 'sid=sid'}
+        packets = _run(s.handle_get_request(environ))
+        self.assertEqual(len(packets), 1)
+        self.assertEqual(packets[0].packet_type, packet.NOOP)
 
     def test_upgrade_not_supported(self):
         mock_server = self._get_mock_server()

--- a/tests/common/test_socket.py
+++ b/tests/common/test_socket.py
@@ -235,6 +235,12 @@ class TestSocket(unittest.TestCase):
             packet.PONG, data=probe).encode(always_bytes=False))
         self.assertEqual(s.queue.get().packet_type, packet.NOOP)
         self.assertFalse(s.upgraded)
+        self.assertTrue(s.poll_ended)
+        start_response = mock.MagicMock()
+        environ = {'REQUEST_METHOD': 'GET', 'QUERY_STRING': 'sid=sid'}
+        packets = s.handle_get_request(environ, start_response)
+        self.assertEqual(len(packets), 1)
+        self.assertEqual(packets[0].packet_type, packet.NOOP)
 
     def test_close_packet(self):
         mock_server = self._get_mock_server()


### PR DESCRIPTION
Should fix:

- https://github.com/miguelgrinberg/python-engineio/issues/160
- https://github.com/miguelgrinberg/python-socketio/issues/393

And deprecate this other PR which seems to indirectly adresses the issue (probably in a less clean way): https://github.com/miguelgrinberg/python-engineio/pull/76

This fixes a race condition between the client side handling of the PONG packet (websocket upgrade) and the NOOP packet queued for the current long polling connexion. The behavior in the Javascript version of the server is here: https://github.com/socketio/engine.io/blob/cb0ac6fddcad12c454651bf0e1a312a154e228a4/lib/transports/polling.js#L112-L117