### PR TITLE
fix on forcing user to disconnect

### DIFF
--- a/engineio/server.py
+++ b/engineio/server.py
@@ -513,7 +513,7 @@ class Server(object):
 
         if transport == 'websocket':
             ret = s.handle_get_request(environ, start_response)
-            if s.closed:
+            if s.closed and sid in self.sockets:
                 # websocket connection ended, so we are done
                 del self.sockets[sid]
             return ret


### PR DESCRIPTION
Am getting this error when I'm trying to force the user to disconnect

```
Traceback (most recent call last):
  File "C:\Users\Deoun\Desktop\*****\server\venv\lib\site-packages\eventlet\wsgi.py", line 566, in handle_one_response
    result = self.application(self.environ, start_response)
  File "C:\Users\Deoun\Desktop\*****\server\venv\lib\site-packages\flask\app.py", line 2464, in __call__
    return self.wsgi_app(environ, start_response)
  File "C:\Users\Deoun\Desktop\*****\server\venv\lib\site-packages\flask_socketio\__init__.py", line 46, in __call__
    start_response)
  File "C:\Users\Deoun\Desktop\*****\server\venv\lib\site-packages\engineio\middleware.py", line 60, in __call__
    return self.engineio_app.handle_request(environ, start_response)
  File "C:\Users\Deoun\Desktop\kittenIM\server\venv\lib\site-packages\socketio\server.py", line 558, in handle_request
    return self.eio.handle_request(environ, start_response)
  File "C:\Users\Deoun\Desktop\*****\server\venv\lib\site-packages\engineio\server.py", line 368, in handle_request
    transport, b64, jsonp_index)
  File "C:\Users\Deoun\Desktop\*****\server\venv\lib\site-packages\engineio\server.py", line 519, in _handle_connect
    del self.sockets[sid]
KeyError: '611ee0e2750f4a26af92b5bbbc545726'
```

How did this happen?

if I save the user session (request.sid) inside my DB then when he's trying to reconnect again so I made a function to force disconnect the old session and it works 100% but when I'm shutting off the wifi connection then turning it on this error showed to me.