### PR TITLE
ASGI lifespan functions

### DIFF
--- a/engineio/async_drivers/asgi.py
+++ b/engineio/async_drivers/asgi.py
@@ -21,6 +21,10 @@ class ASGIApp:
     :param engineio_path: The endpoint where the Engine.IO application should
                           be installed. The default value is appropriate for
                           most cases.
+    :param on_startup: function to be called on application startup; can be
+                       coroutine
+    :param on_shutdown: function to be called on application shutdown; can be
+                        coroutine
 
     Example usage::
 
@@ -82,17 +86,27 @@ class ASGIApp:
         if event['type'] == 'lifespan.startup':
             if self.on_startup:
                 try:
-                    await self.on_startup() if asyncio.iscoroutinefunction(self.on_startup) else self.on_startup()
+                    (await self.on_startup()
+                     if asyncio.iscoroutinefunction(self.on_startup)
+                     else self.on_startup())
                 except:
-                    await send({'type': 'lifespan.startup.failed', 'message': traceback.format_exc()})
+                    await send({
+                        'type': 'lifespan.startup.failed',
+                        'message': traceback.format_exc()
+                    })
                     return
             await send({'type': 'lifespan.startup.complete'})
         elif event['type'] == 'lifespan.shutdown':
             if self.on_shutdown:
                 try:
-                    await self.on_shutdown() if asyncio.iscoroutinefunction(self.on_shutdown) else self.on_shutdown()
+                    (await self.on_shutdown()
+                     if asyncio.iscoroutinefunction(self.on_shutdown)
+                     else self.on_shutdown())
                 except:
-                    await send({'type': 'lifespan.shutdown.failed', 'message': traceback.format_exc()})
+                    await send({
+                        'type': 'lifespan.shutdown.failed',
+                        'message': traceback.format_exc()
+                    })
                     return
             await send({'type': 'lifespan.shutdown.complete'})
 

--- a/tests/asyncio/test_async_asgi.py
+++ b/tests/asyncio/test_async_asgi.py
@@ -116,6 +116,47 @@ class AsgiTests(unittest.TestCase):
         send.mock.assert_called_once_with(
             {'type': 'lifespan.startup.complete'})
 
+        # sync startup function
+        up = False
+        def startup():
+            nonlocal up
+            up = True
+        app = async_asgi.ASGIApp('eio', on_startup=startup)
+        scope = {'type': 'lifespan'}
+        receive = AsyncMock(return_value={'type': 'lifespan.startup'})
+        send = AsyncMock()
+        _run(app(scope, receive, send))
+        send.mock.assert_called_once_with(
+            {'type': 'lifespan.startup.complete'})
+        self.assertTrue(up)
+        
+        # async startup function
+        up = False
+        async def startup():
+            nonlocal up
+            up = True
+        app = async_asgi.ASGIApp('eio', on_startup=startup)
+        scope = {'type': 'lifespan'}
+        receive = AsyncMock(return_value={'type': 'lifespan.startup'})
+        send = AsyncMock()
+        _run(app(scope, receive, send))
+        send.mock.assert_called_once_with(
+            {'type': 'lifespan.startup.complete'})
+        self.assertTrue(up)
+        
+        # startup function exception
+        up = False
+        def startup():
+            raise Exception
+        app = async_asgi.ASGIApp('eio', on_startup=startup)
+        scope = {'type': 'lifespan'}
+        receive = AsyncMock(return_value={'type': 'lifespan.startup'})
+        send = AsyncMock()
+        _run(app(scope, receive, send))
+        send.mock.assert_called_once_with(
+            {'type': 'lifespan.startup.failed', 'message': unittest.mock.ANY})
+        self.assertFalse(up)
+
     def test_lifespan_shutdown(self):
         app = async_asgi.ASGIApp('eio')
         scope = {'type': 'lifespan'}
@@ -124,6 +165,47 @@ class AsgiTests(unittest.TestCase):
         _run(app(scope, receive, send))
         send.mock.assert_called_once_with(
             {'type': 'lifespan.shutdown.complete'})
+
+        # sync shutdown function
+        down = False
+        def shutdown():
+            nonlocal down
+            down = True
+        app = async_asgi.ASGIApp('eio', on_shutdown=shutdown)
+        scope = {'type': 'lifespan'}
+        receive = AsyncMock(return_value={'type': 'lifespan.shutdown'})
+        send = AsyncMock()
+        _run(app(scope, receive, send))
+        send.mock.assert_called_once_with(
+            {'type': 'lifespan.shutdown.complete'})
+        self.assertTrue(down)
+        
+        # async shutdown function
+        down = False
+        async def shutdown():
+            nonlocal down
+            down = True
+        app = async_asgi.ASGIApp('eio', on_shutdown=shutdown)
+        scope = {'type': 'lifespan'}
+        receive = AsyncMock(return_value={'type': 'lifespan.shutdown'})
+        send = AsyncMock()
+        _run(app(scope, receive, send))
+        send.mock.assert_called_once_with(
+            {'type': 'lifespan.shutdown.complete'})
+        self.assertTrue(down)
+        
+        # shutdown function exception
+        down = False
+        def shutdown():
+            raise Exception
+        app = async_asgi.ASGIApp('eio', on_shutdown=shutdown)
+        scope = {'type': 'lifespan'}
+        receive = AsyncMock(return_value={'type': 'lifespan.shutdown'})
+        send = AsyncMock()
+        _run(app(scope, receive, send))
+        send.mock.assert_called_once_with(
+            {'type': 'lifespan.shutdown.failed', 'message': unittest.mock.ANY})
+        self.assertFalse(down)
 
     def test_lifespan_invalid(self):
         app = async_asgi.ASGIApp('eio')

--- a/tests/asyncio/test_async_asgi.py
+++ b/tests/asyncio/test_async_asgi.py
@@ -118,6 +118,7 @@ class AsgiTests(unittest.TestCase):
 
         # sync startup function
         up = False
+
         def startup():
             nonlocal up
             up = True
@@ -129,9 +130,10 @@ class AsgiTests(unittest.TestCase):
         send.mock.assert_called_once_with(
             {'type': 'lifespan.startup.complete'})
         self.assertTrue(up)
-        
+
         # async startup function
         up = False
+
         async def startup():
             nonlocal up
             up = True
@@ -143,9 +145,10 @@ class AsgiTests(unittest.TestCase):
         send.mock.assert_called_once_with(
             {'type': 'lifespan.startup.complete'})
         self.assertTrue(up)
-        
+
         # startup function exception
         up = False
+
         def startup():
             raise Exception
         app = async_asgi.ASGIApp('eio', on_startup=startup)
@@ -168,6 +171,7 @@ class AsgiTests(unittest.TestCase):
 
         # sync shutdown function
         down = False
+
         def shutdown():
             nonlocal down
             down = True
@@ -179,9 +183,10 @@ class AsgiTests(unittest.TestCase):
         send.mock.assert_called_once_with(
             {'type': 'lifespan.shutdown.complete'})
         self.assertTrue(down)
-        
+
         # async shutdown function
         down = False
+
         async def shutdown():
             nonlocal down
             down = True
@@ -193,9 +198,10 @@ class AsgiTests(unittest.TestCase):
         send.mock.assert_called_once_with(
             {'type': 'lifespan.shutdown.complete'})
         self.assertTrue(down)
-        
+
         # shutdown function exception
         down = False
+
         def shutdown():
             raise Exception
         app = async_asgi.ASGIApp('eio', on_shutdown=shutdown)


### PR DESCRIPTION
Added parameters `on_startup` and `on_shutdown` to `ASGIApp` which are functions that are called on receiving their corresponding ASGI event (`'lifespan.startup'` and `'lifespan.shutdown'`). Also updated tests and doc strings. Adapted from [starlette implementation](https://github.com/encode/starlette/blob/5b38e832df5f0b7ec82f3fd04c57d9581c104d36/starlette/routing.py#L508).