### PR TITLE
Add ability to set enable_multithread in websocket.create_connection()

### DIFF
--- a/engineio/client.py
+++ b/engineio/client.py
@@ -100,6 +100,7 @@ class Client(object):
         self.queue = None
         self.state = 'disconnected'
         self.ssl_verify = ssl_verify
+        self.ssl_enable_multithread = False
 
         if json is not None:
             packet.Packet.json = json
@@ -369,14 +370,20 @@ class Client(object):
                     break
 
         try:
+            extra_options = {}
+            if self.ssl_enable_multithread:
+                extra_options.update({
+                    "enable_multithread": True
+                })
             if not self.ssl_verify:
-                ws = websocket.create_connection(
-                    websocket_url + self._get_url_timestamp(), header=headers,
-                    cookie=cookies, sslopt={"cert_reqs": ssl.CERT_NONE})
-            else:
-                ws = websocket.create_connection(
-                    websocket_url + self._get_url_timestamp(), header=headers,
-                    cookie=cookies)
+                extra_options.update({
+                    "sslopt": {
+                        "cert_reqs": ssl.CERT_NONE
+                    }
+                })
+            ws = websocket.create_connection(
+                websocket_url + self._get_url_timestamp(), header=headers,
+                cookie=cookies, **extra_options)
         except (ConnectionError, IOError, websocket.WebSocketException):
             if upgrade:
                 self.logger.warning(


### PR DESCRIPTION
As discussed here https://github.com/miguelgrinberg/python-socketio/issues/451

Here is a proposal to handle the issue:

- It does not change current behavior
- Did not add the option in constructor to keep `AsyncClient` and `Client` consistent
- `aiohttp` does not have such option when creating the websocket so no need to implement anything in Async side
- Factorize `create_connection()` calls

