### PR TITLE
Added HTTP proxy support

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -83,6 +83,20 @@ In the case of the ``asyncio`` client, the method is a coroutine::
 
     await eio.connect('http://localhost:5000')
 
+If the application is behind a firewall or you need to use proxies::
+
+    eio._set_proxy('http://localhost:3128')
+
+Or when the client is initialized::
+
+    import engineio
+
+    # standard Python
+    eio = engineio.Client(proxy='http://localhost:3128')
+
+    # asyncio
+    eio = engineio.AsyncClient(proxy='http://localhost:3128')
+
 Upon connection, the server assigns the client a unique session identifier.
 The applicaction can find this identifier in the ``sid`` attribute::
 

--- a/engineio/asyncio_client.py
+++ b/engineio/asyncio_client.py
@@ -34,6 +34,11 @@ class AsyncClient(client.Client):
                        skip SSL certificate verification, allowing
                        connections to servers with self signed certificates.
                        The default is ``True``.
+    :param proxy: An HTTP proxy to be used in the websocket connection.
+                  e.g. "http://proxy.com:3128"
+                  Authentication credentials can be passed in proxy URL.
+                  e.g. "http://user:pass@some.proxy.com:3128"
+                  Default is ``None``.
     """
     def is_asyncio_based(self):
         return True

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -815,7 +815,7 @@ class TestClient(unittest.TestCase):
             ((packet.Packet(packet.UPGRADE).encode(),),))  # upgrade
 
     @mock.patch('engineio.client.websocket.create_connection')
-    def test_websocket_connection_successful_with_proxy(self, create_connection):
+    def test_websocket_connection_proxy_successful_w(self, create_connection):
         create_connection.return_value.recv.return_value = packet.Packet(
             packet.OPEN, {
                 'sid': '123', 'upgrades': [], 'pingInterval': 1000,


### PR DESCRIPTION
This pull request allows developers to establish a proxy when they initialize a python-engineio client. This is particularly useful for connecting to the server when behind a firewall.

I made the changes to make this an optional feature. Although some changes are required in the lib python-socketio to fully benefit from this feature.

I also took the liberty of adding it to the documentation on how to set up a proxy.