### PR TITLE
Do not catch GeneratorExit and etc.

### DIFF
--- a/engineio/asyncio_server.py
+++ b/engineio/asyncio_server.py
@@ -460,10 +460,15 @@ class AsyncServer(server.Server):
                     if not socket.closing and not socket.closed:
                         await socket.check_ping_timeout()
                     await self.sleep(sleep_interval)
-            except (SystemExit, KeyboardInterrupt, asyncio.CancelledError):
+            except (
+                SystemExit,
+                KeyboardInterrupt,
+                asyncio.CancelledError,
+                GeneratorExit,
+            ):
                 self.logger.info('service task canceled')
                 break
-            except Exception:
+            except:
                 if asyncio.get_event_loop().is_closed():
                     self.logger.info('event loop is closed, exiting service '
                                      'task')

--- a/engineio/asyncio_server.py
+++ b/engineio/asyncio_server.py
@@ -463,7 +463,7 @@ class AsyncServer(server.Server):
             except (SystemExit, KeyboardInterrupt, asyncio.CancelledError):
                 self.logger.info('service task canceled')
                 break
-            except:
+            except Exception:
                 if asyncio.get_event_loop().is_closed():
                     self.logger.info('event loop is closed, exiting service '
                                      'task')


### PR DESCRIPTION
Now we catch GeneratorExit here https://github.com/miguelgrinberg/python-engineio/blob/master/engineio/asyncio_server.py#L466 and keep iterating - loop is not closed yet and there is no break/return in the end.
I think we can just catch Exception.