### PR TITLE
WIP: Ensure tests pass on either linux or windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 example/wsgi/static/engine.io.js linguist-vendored
 example/aiohttp/static/engine.io.js linguist-vendored
+
+tests/asyncio/index.html -text
+tests/common/index.html -text

--- a/tests/asyncio/test_async_asgi.py
+++ b/tests/asyncio/test_async_asgi.py
@@ -94,27 +94,31 @@ class AsgiTests(unittest.TestCase):
                 {'type': 'http.response.body', 'body': body.encode('utf-8')}
             )
 
-        check_path('/', 200, 'text/html', '<html></html>\n')
-        check_path('/foo', 200, 'text/plain', '<html></html>\n')
-        check_path('/static/index.html', 200, 'text/html', '<html></html>\n')
+        empty_html_body = '<html></html>\n'
+        if sys.platform.startswith("win"):
+            empty_html_body = '<html></html>\r\n'
+
+        check_path('/', 200, 'text/html', empty_html_body)
+        check_path('/foo', 200, 'text/plain', empty_html_body)
+        check_path('/static/index.html', 200, 'text/html', empty_html_body)
         check_path('/static/foo.bar', 404, 'text/plain', 'Not Found')
         check_path(
-            '/static/test/index.html', 200, 'text/html', '<html></html>\n'
+            '/static/test/index.html', 200, 'text/html', empty_html_body
         )
         check_path('/bar/foo', 404, 'text/plain', 'Not Found')
         check_path('', 404, 'text/plain', 'Not Found')
 
         app.static_files[''] = 'index.html'
-        check_path('/static/test/', 200, 'text/html', '<html></html>\n')
+        check_path('/static/test/', 200, 'text/html', empty_html_body)
 
         app.static_files[''] = {'filename': 'index.html'}
-        check_path('/static/test/', 200, 'text/html', '<html></html>\n')
+        check_path('/static/test/', 200, 'text/html', empty_html_body)
 
         app.static_files[''] = {
             'filename': 'index.html',
             'content_type': 'image/gif',
         }
-        check_path('/static/test/', 200, 'image/gif', '<html></html>\n')
+        check_path('/static/test/', 200, 'image/gif', empty_html_body)
 
         app.static_files[''] = {'filename': 'test.gif'}
         check_path('/static/test/', 404, 'text/plain', 'Not Found')

--- a/tests/asyncio/test_async_asgi.py
+++ b/tests/asyncio/test_async_asgi.py
@@ -95,8 +95,8 @@ class AsgiTests(unittest.TestCase):
             )
 
         empty_html_body = '<html></html>\n'
-        if sys.platform.startswith("win"):
-            empty_html_body = '<html></html>\r\n'
+        # if sys.platform.startswith("win"):
+        #     empty_html_body = '<html></html>\r\n'
 
         check_path('/', 200, 'text/html', empty_html_body)
         check_path('/foo', 200, 'text/plain', empty_html_body)

--- a/tests/common/test_middleware.py
+++ b/tests/common/test_middleware.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import unittest
 
 import six
@@ -60,8 +59,8 @@ class TestWSGIApp(unittest.TestCase):
             )
 
         empty_html_body = '<html></html>\n'
-        if sys.platform.startswith("win"):
-            empty_html_body = '<html></html>\r\n'
+        # if sys.platform.startswith("win"):
+        #     empty_html_body = '<html></html>\r\n'
 
         check_path('/', '200 OK', 'text/html', empty_html_body)
         check_path('/foo', '200 OK', 'text/plain', empty_html_body)

--- a/tests/common/test_middleware.py
+++ b/tests/common/test_middleware.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 
 import six
@@ -58,32 +59,36 @@ class TestWSGIApp(unittest.TestCase):
                 status_code, [('Content-Type', content_type)]
             )
 
-        check_path('/', '200 OK', 'text/html', '<html></html>\n')
-        check_path('/foo', '200 OK', 'text/plain', '<html></html>\n')
+        empty_html_body = '<html></html>\n'
+        if sys.platform.startswith("win"):
+            empty_html_body = '<html></html>\r\n'
+
+        check_path('/', '200 OK', 'text/html', empty_html_body)
+        check_path('/foo', '200 OK', 'text/plain', empty_html_body)
         check_path(
-            '/static/index.html', '200 OK', 'text/html', '<html></html>\n'
+            '/static/index.html', '200 OK', 'text/html', empty_html_body
         )
         check_path(
             '/static/foo.bar', '404 Not Found', 'text/plain', 'Not Found'
         )
         check_path(
-            '/static/test/index.html', '200 OK', 'text/html', '<html></html>\n'
+            '/static/test/index.html', '200 OK', 'text/html', empty_html_body
         )
-        check_path('/static/test/', '200 OK', 'text/html', '<html></html>\n')
+        check_path('/static/test/', '200 OK', 'text/html', empty_html_body)
         check_path('/bar/foo', '404 Not Found', 'text/plain', 'Not Found')
         check_path('', '404 Not Found', 'text/plain', 'Not Found')
 
         m.static_files[''] = 'index.html'
-        check_path('/static/test/', '200 OK', 'text/html', '<html></html>\n')
+        check_path('/static/test/', '200 OK', 'text/html', empty_html_body)
 
         m.static_files[''] = {'filename': 'index.html'}
-        check_path('/static/test/', '200 OK', 'text/html', '<html></html>\n')
+        check_path('/static/test/', '200 OK', 'text/html', empty_html_body)
 
         m.static_files[''] = {
             'filename': 'index.html',
             'content_type': 'image/gif',
         }
-        check_path('/static/test/', '200 OK', 'image/gif', '<html></html>\n')
+        check_path('/static/test/', '200 OK', 'image/gif', empty_html_body)
 
         m.static_files[''] = {'filename': 'test.gif'}
         check_path('/static/test/', '404 Not Found', 'text/plain', 'Not Found')


### PR DESCRIPTION
check_path(...) was raising errors on windows since the returned empty html body does not contain the same newline character depending on the platform.

Since I couldn't see any shared test helpers or config, I advised against creating one just for this variable and just duplicated the code. (If you'd rather extract that to a constant in a shared config / helper file, let me know.)

I ran tox on both linux (3,5 and 3.8) and windows (3.8) and everything seems good to go on my side.