### PR TITLE
Make sure Async client does not fail to connect on Windows

### DIFF
--- a/engineio/asyncio_client.py
+++ b/engineio/asyncio_client.py
@@ -1,7 +1,6 @@
 import asyncio
 import signal
 import ssl
-import sys
 import threading
 
 try:
@@ -87,12 +86,15 @@ class AsyncClient(client.Client):
         """
         global async_signal_handler_set
         if not async_signal_handler_set and \
-                threading.current_thread() == threading.main_thread() and \
-                not sys.platform.startswith("win"):
+                threading.current_thread() == threading.main_thread():
 
-            asyncio.get_event_loop().add_signal_handler(signal.SIGINT,
-                                                        async_signal_handler)
-            async_signal_handler_set = True
+            try:
+                asyncio.get_event_loop() \
+                    .add_signal_handler(signal.SIGINT, async_signal_handler)
+                async_signal_handler_set = True
+            except NotImplementedError as error:
+                self.logger.debug(error)
+
         if self.state != 'disconnected':
             raise ValueError('Client is not in a disconnected state')
         valid_transports = ['polling', 'websocket']

--- a/engineio/asyncio_client.py
+++ b/engineio/asyncio_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import signal
 import ssl
+import sys
 import threading
 
 try:
@@ -86,7 +87,9 @@ class AsyncClient(client.Client):
         """
         global async_signal_handler_set
         if not async_signal_handler_set and \
-                threading.current_thread() == threading.main_thread():
+                threading.current_thread() == threading.main_thread() and \
+                not sys.platform.startswith("win"):
+
             asyncio.get_event_loop().add_signal_handler(signal.SIGINT,
                                                         async_signal_handler)
             async_signal_handler_set = True


### PR DESCRIPTION
Add verification that we're not on windows before trying to add a signal handler since this is not supported on that platform.

I'm not quite sure whether or not there would be a better way, but I think this is a pretty quick change. 

I've ran tests on tox, both on linux and on windows and it runs fine ([This other PR](https://github.com/miguelgrinberg/python-engineio/pull/198) of mine proposes a way to fix some "broken" tests on Windows)

The only downside I see is that the coverage dropped from 100% to 99%.

It's getting late so I haven't tried it yet, but adapting this [answer](https://stackoverflow.com/a/35542296) could be promising.
I can give it a try if keeping the perfect score is required to accept the PR 😄  