### PR TITLE
Handle non-integer ping interval and timeout

### DIFF
--- a/engineio/client.py
+++ b/engineio/client.py
@@ -481,8 +481,8 @@ class Client(object):
                 'WebSocket connection accepted with ' + str(open_packet.data))
             self.sid = open_packet.data['sid']
             self.upgrades = open_packet.data['upgrades']
-            self.ping_interval = open_packet.data['pingInterval'] / 1000.0
-            self.ping_timeout = open_packet.data['pingTimeout'] / 1000.0
+            self.ping_interval = int(open_packet.data['pingInterval']) / 1000.0
+            self.ping_timeout = int(open_packet.data['pingTimeout']) / 1000.0
             self.current_transport = 'websocket'
 
             self.state = 'connected'


### PR DESCRIPTION
Some socket.io servers (non python) serve `ping_timeout` and `ping_interval` as strings rather than integers, this is causing the client to break at startup.

for reference, here's a response from a server I am connecting to -
```
INFO:engineio.client:WebSocket connection accepted with {'sid': 'some_long_sid', 'upgrades': [], 'pingInterval': '15000', 'pingTimeout': '10000'}
```