### PR TITLE
Ignore case when comparing Socket.IO transport param with HTTP_UPGRADE header

### DIFF
--- a/engineio/server.py
+++ b/engineio/server.py
@@ -379,15 +379,18 @@ class Server(object):
         elif method == 'GET':
             if sid is None:
                 transport = query.get('transport', ['polling'])[0]
-                if (transport != 'polling' and transport != 'websocket') or \
-                        (transport != 'polling'
-                            and transport != environ.get('HTTP_UPGRADE')):
+                # transport must be one of: 'polling' or 'websocket'.
+                # If 'websocket', the HTTP_UPGRADE header must match.
+                # Some tech likes to use 'WebSocket', so ignore case.
+                upgrade_header = environ.get('HTTP_UPGRADE', '').lower()
+                if transport == 'polling' \
+                        or transport == upgrade_header == 'websocket':
+                    r = self._handle_connect(environ, start_response,
+                                             transport, b64, jsonp_index)
+                else:
                     self._log_error_once('Invalid transport ' + transport,
                                          'bad-transport')
                     r = self._bad_request('Invalid transport ' + transport)
-                else:
-                    r = self._handle_connect(environ, start_response,
-                                             transport, b64, jsonp_index)
             else:
                 if sid not in self.sockets:
                     self._log_error_once('Invalid session ' + sid, 'bad-sid')

--- a/tests/common/test_server.py
+++ b/tests/common/test_server.py
@@ -572,6 +572,24 @@ class TestServer(unittest.TestCase):
         'engineio.socket.Socket',
         return_value=mock.MagicMock(connected=False, closed=False),
     )
+    def test_http_upgrade_case_insensitive(self, Socket):
+        s = server.Server()
+        s._generate_id = mock.MagicMock(return_value='123')
+        environ = {
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': 'EIO=3&transport=websocket',
+            'HTTP_UPGRADE': 'WebSocket',
+        }
+        start_response = mock.MagicMock()
+        # force socket to stay open, so that we can check it later
+        Socket().closed = False
+        s.handle_request(environ, start_response)
+        assert s.sockets['123'].send.call_args[0][0].packet_type == packet.OPEN
+
+    @mock.patch(
+        'engineio.socket.Socket',
+        return_value=mock.MagicMock(connected=False, closed=False),
+    )
     def test_connect_transport_websocket_closed(self, Socket):
         s = server.Server()
         s._generate_id = mock.MagicMock(return_value='123')


### PR DESCRIPTION
When proxying websocket connections via `mod_proxy_wstunnel`, Apache sets the HTTP Upgrade header to `Upgrade: WebSocket`. Hence, validation of the `websocket` transport should include this variant, and making the comparison case-insensitive does the trick.

Tests have been added where appropriate to confirm the problem and verify the solution.