### PR TITLE
support for client to verify server with custom ca bundle

### DIFF
--- a/engineio/client.py
+++ b/engineio/client.py
@@ -64,18 +64,11 @@ class Client(object):
     :param http_session: an initialized ``requests.Session`` object to be used
                          when sending requests to the server. Use it if you
                          need to add special client options such as proxy
-                         servers, SSL certificates, etc.
-    :param ssl_verify: (optional) Either a boolean, in which case it controls
-                       whether we verify the server's SSL certificate, or a
-                       string, in which case it must be a path to a CA bundle
-                       to use. Defaults to ``True``. When set to ``False``,
-                       SSL certificate verification is skipped, allowing
-                       connections to servers with self signed certificates,
-                       and will ignore hostname mismatches and/or expired
-                       certificates, which will make your application
-                       vulnerable to man-in-the-middle (MitM) attacks.
-                       Setting ssl_verify to ``False`` may be useful
-                       during local development or testing.
+                         servers, SSL certificates, custom ca bundle, etc.
+    :param ssl_verify: ``True`` to verify SSL certificates, or ``False`` to
+                       skip SSL certificate verification, allowing
+                       connections to servers with self signed certificates.
+                       The default is ``True``.
     """
     event_names = ['connect', 'disconnect', 'message']
 
@@ -411,13 +404,16 @@ class Client(object):
                         if parsed_url.username or parsed_url.password
                         else None)
 
-        # verify
-        if isinstance(self.ssl_verify, str):
-            if 'sslopt' in extra_options:
-                extra_options['sslopt']['ca_certs'] = self.ssl_verify
-            else:
-                extra_options['sslopt'] = {'ca_certs': self.ssl_verify}
-        elif not self.ssl_verify:
+            # verify
+            if isinstance(self.http.verify, str):
+                if 'sslopt' in extra_options:
+                    extra_options['sslopt']['ca_certs'] = self.http.verify
+                else:
+                    extra_options['sslopt'] = {'ca_certs': self.http.verify}
+            elif not self.http.verify:
+                self.ssl_verify = False
+
+        if not self.ssl_verify:
             extra_options['sslopt'] = {"cert_reqs": ssl.CERT_NONE}
         try:
             ws = websocket.create_connection(
@@ -524,9 +520,11 @@ class Client(object):
             timeout=None):  # pragma: no cover
         if self.http is None:
             self.http = requests.Session()
+        if not self.ssl_verify:
+            self.http.verify = False
         try:
             return self.http.request(method, url, headers=headers, data=body,
-                                     timeout=timeout, verify=self.ssl_verify)
+                                     timeout=timeout, verify=self.http.verify)
         except requests.exceptions.RequestException as exc:
             self.logger.info('HTTP %s request to %s failed with error %s.',
                              method, url, exc)

--- a/engineio/client.py
+++ b/engineio/client.py
@@ -524,7 +524,7 @@ class Client(object):
             self.http.verify = False
         try:
             return self.http.request(method, url, headers=headers, data=body,
-                                     timeout=timeout, verify=self.http.verify)
+                                     timeout=timeout)
         except requests.exceptions.RequestException as exc:
             self.logger.info('HTTP %s request to %s failed with error %s.',
                              method, url, exc)

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -898,6 +898,47 @@ class TestClient(unittest.TestCase):
         }
 
     @mock.patch('engineio.client.websocket.create_connection')
+    def test_websocket_connection_verify_with_cert_and_key(
+        self, create_connection
+    ):
+        create_connection.return_value.recv.return_value = packet.Packet(
+            packet.OPEN,
+            {
+                'sid': '123',
+                'upgrades': [],
+                'pingInterval': 1000,
+                'pingTimeout': 2000,
+            },
+        ).encode()
+        http = mock.MagicMock()
+        http.cookies = []
+        http.auth = None
+        http.proxies = None
+        http.cert = ('foo.crt', 'key.pem')
+        c = client.Client(
+            http_session=http,
+            ssl_verify='/path/to/ca-bundle.crt'
+        )
+        c._read_loop_polling = mock.MagicMock()
+        c._read_loop_websocket = mock.MagicMock()
+        c._write_loop = mock.MagicMock()
+        on_connect = mock.MagicMock()
+        c.on('connect', on_connect)
+        c.connect('ws://foo', transports=['websocket'])
+
+        assert len(create_connection.call_args_list) == 1
+        assert create_connection.call_args[1] == {
+            'sslopt': {
+                'certfile': 'foo.crt',
+                'keyfile': 'key.pem',
+                'ca_certs': '/path/to/ca-bundle.crt'
+            },
+            'header': {},
+            'cookie': '',
+            'enable_multithread': True,
+        }
+
+    @mock.patch('engineio.client.websocket.create_connection')
     def test_websocket_connection_with_proxies(self, create_connection):
         all_urls = [
             'ws://foo',
@@ -979,8 +1020,7 @@ class TestClient(unittest.TestCase):
         http.auth = None
         http.proxies = None
         http.cert = None
-        http.verify = False
-        c = client.Client(http_session=http)
+        c = client.Client(http_session=http, ssl_verify=False)
         c._read_loop_polling = mock.MagicMock()
         c._read_loop_websocket = mock.MagicMock()
         c._write_loop = mock.MagicMock()
@@ -991,6 +1031,41 @@ class TestClient(unittest.TestCase):
         assert len(create_connection.call_args_list) == 1
         assert create_connection.call_args[1] == {
             'sslopt': {"cert_reqs": ssl.CERT_NONE},
+            'header': {},
+            'cookie': '',
+            'enable_multithread': True,
+        }
+
+    @mock.patch('engineio.client.websocket.create_connection')
+    def test_websocket_connection_with_verify(self, create_connection):
+        create_connection.return_value.recv.return_value = packet.Packet(
+            packet.OPEN,
+            {
+                'sid': '123',
+                'upgrades': [],
+                'pingInterval': 1000,
+                'pingTimeout': 2000,
+            },
+        ).encode()
+        http = mock.MagicMock()
+        http.cookies = []
+        http.auth = None
+        http.proxies = None
+        http.cert = None
+        c = client.Client(
+            http_session=http,
+            ssl_verify='/path/to/ca-bundle.crt'
+        )
+        c._read_loop_polling = mock.MagicMock()
+        c._read_loop_websocket = mock.MagicMock()
+        c._write_loop = mock.MagicMock()
+        on_connect = mock.MagicMock()
+        c.on('connect', on_connect)
+        c.connect('ws://foo', transports=['websocket'])
+
+        assert len(create_connection.call_args_list) == 1
+        assert create_connection.call_args[1] == {
+            'sslopt': {'ca_certs': '/path/to/ca-bundle.crt'},
             'header': {},
             'cookie': '',
             'enable_multithread': True,

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -915,10 +915,8 @@ class TestClient(unittest.TestCase):
         http.auth = None
         http.proxies = None
         http.cert = ('foo.crt', 'key.pem')
-        c = client.Client(
-            http_session=http,
-            ssl_verify='/path/to/ca-bundle.crt'
-        )
+        http.verify = 'ca-bundle.crt'
+        c = client.Client(http_session=http)
         c._read_loop_polling = mock.MagicMock()
         c._read_loop_websocket = mock.MagicMock()
         c._write_loop = mock.MagicMock()
@@ -931,7 +929,7 @@ class TestClient(unittest.TestCase):
             'sslopt': {
                 'certfile': 'foo.crt',
                 'keyfile': 'key.pem',
-                'ca_certs': '/path/to/ca-bundle.crt'
+                'ca_certs': 'ca-bundle.crt'
             },
             'header': {},
             'cookie': '',
@@ -1020,7 +1018,8 @@ class TestClient(unittest.TestCase):
         http.auth = None
         http.proxies = None
         http.cert = None
-        c = client.Client(http_session=http, ssl_verify=False)
+        http.verify = False
+        c = client.Client(http_session=http)
         c._read_loop_polling = mock.MagicMock()
         c._read_loop_websocket = mock.MagicMock()
         c._write_loop = mock.MagicMock()
@@ -1052,10 +1051,8 @@ class TestClient(unittest.TestCase):
         http.auth = None
         http.proxies = None
         http.cert = None
-        c = client.Client(
-            http_session=http,
-            ssl_verify='/path/to/ca-bundle.crt'
-        )
+        http.verify = 'ca-bundle.crt'
+        c = client.Client(http_session=http)
         c._read_loop_polling = mock.MagicMock()
         c._read_loop_websocket = mock.MagicMock()
         c._write_loop = mock.MagicMock()
@@ -1065,7 +1062,7 @@ class TestClient(unittest.TestCase):
 
         assert len(create_connection.call_args_list) == 1
         assert create_connection.call_args[1] == {
-            'sslopt': {'ca_certs': '/path/to/ca-bundle.crt'},
+            'sslopt': {'ca_certs': 'ca-bundle.crt'},
             'header': {},
             'cookie': '',
             'enable_multithread': True,


### PR DESCRIPTION
Adds feature discussed in https://github.com/miguelgrinberg/python-socketio/issues/626

Directly specify path to custom ca bundle using `ssl_verify`

Polling transport already works. This adds support for websocket transport to work as well.