### PR TITLE
Remove obsolete 'mock' dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         ]
     },
     tests_require=[
-        'mock',
         'eventlet',
     ],
     test_suite='tests',


### PR DESCRIPTION
The package is using 'unittest.mock' consistently, so remove
the obsolete dependency.