### PR TITLE
fix: Use plaintext Content-Type when using polling

### DIFF
--- a/src/engineio/asyncio_client.py
+++ b/src/engineio/asyncio_client.py
@@ -586,7 +586,7 @@ class AsyncClient(client.Client):
                 p = payload.Payload(packets=packets)
                 r = await self._send_request(
                     'POST', self.base_url, body=p.encode(),
-                    headers={'Content-Type': 'application/octet-stream'},
+                    headers={'Content-Type': 'text/plain'},
                     timeout=self.request_timeout)
                 for pkt in packets:
                     self.queue.task_done()

--- a/src/engineio/client.py
+++ b/src/engineio/client.py
@@ -680,7 +680,7 @@ class Client(object):
                 p = payload.Payload(packets=packets)
                 r = self._send_request(
                     'POST', self.base_url, body=p.encode(),
-                    headers={'Content-Type': 'application/octet-stream'},
+                    headers={'Content-Type': 'text/plain'},
                     timeout=self.request_timeout)
                 for pkt in packets:
                     self.queue.task_done()

--- a/tests/asyncio/test_asyncio_client.py
+++ b/tests/asyncio/test_asyncio_client.py
@@ -1211,7 +1211,7 @@ class TestAsyncClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
 
@@ -1252,7 +1252,7 @@ class TestAsyncClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
 
@@ -1288,7 +1288,7 @@ class TestAsyncClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
         assert c.state == 'connected'
@@ -1316,7 +1316,7 @@ class TestAsyncClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
         assert c.state == 'connected'
@@ -1345,7 +1345,7 @@ class TestAsyncClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
         assert c.state == 'disconnected'

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -1466,7 +1466,7 @@ class TestClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
 
@@ -1501,7 +1501,7 @@ class TestClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
 
@@ -1534,7 +1534,7 @@ class TestClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
         assert c.state == 'connected'
@@ -1563,7 +1563,7 @@ class TestClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
         assert c.state == 'connected'
@@ -1592,7 +1592,7 @@ class TestClient(unittest.TestCase):
             'POST',
             'http://foo',
             body=p.encode(),
-            headers={'Content-Type': 'application/octet-stream'},
+            headers={'Content-Type': 'text/plain'},
             timeout=5,
         )
         assert c.state == 'disconnected'


### PR DESCRIPTION
When using polling with engine.io protocol version 4, payloads with binary data must be encoded in Base64. Hence, the content type send to the server is not 'application/octet-stream' but rather 'text/plain'.

See [difference between v3 and v4](https://github.com/socketio/engine.io-protocol#difference-between-v3-and-v4) and the [reference JavaScript implementation](https://github.com/socketio/engine.io/blob/4c0aa73e060f4e2fecdea345fe600f0c29ef575e/lib/transports/polling.js#L111).

Closes #247 