### PR TITLE
Adding basic back pressure ability

### DIFF
--- a/src/engineio/asyncio_server.py
+++ b/src/engineio/asyncio_server.py
@@ -63,6 +63,12 @@ class AsyncServer(server.Server):
     :param async_handlers: If set to ``True``, run message event handlers in
                            non-blocking threads. To run handlers synchronously,
                            set to ``False``. The default is ``True``.
+    :param back_pressure_size: The size to limit the Socket queue if packets
+                               going to the client are allowed to be dropped
+                               in the senario in which a client is not recieving
+                               packets. This prevents buffering on the server side
+                               but risks packet loss. Set only if data reliability
+                               is not essential.
     :param kwargs: Reserved for future extensions, any additional parameters
                    given as keyword arguments will be silently ignored.
     """
@@ -93,7 +99,7 @@ class AsyncServer(server.Server):
             # the socket is not available
             self.logger.warning('Cannot send to sid %s', sid)
             return
-        await socket.send(packet.Packet(packet.MESSAGE, data=data))
+        await socket.send(packet.Packet(packet.MESSAGE, data=data), apply_bp=self.back_pressure_size is not None)
 
     async def get_session(self, sid):
         """Return the user session for a client.

--- a/tests/common/test_server.py
+++ b/tests/common/test_server.py
@@ -829,6 +829,16 @@ class TestServer(unittest.TestCase):
         assert mock_socket.send.call_count == 1
         assert mock_socket.send.call_args[0][0].packet_type == packet.MESSAGE
         assert mock_socket.send.call_args[0][0].data == 'hello'
+        assert mock_socket.send.call_args[1] == False
+
+    def test_send_back_pressure(self):
+        s = server.Server(back_pressure_size=5)
+        mock_socket = self._get_mock_socket()
+        s.sockets['foo'] = mock_socket
+        assert mock_socket.send.call_count == 1
+        assert mock_socket.send.call_args[0][0].packet_type == packet.MESSAGE
+        assert mock_socket.send.call_args[0][0].data == 'hello'
+        assert mock_socket.send.call_args[1] == True
 
     def test_send_unknown_socket(self):
         s = server.Server()


### PR DESCRIPTION
Adds a back_pressure argument to the Socket.py send() function. This is an argument that has to be >= 1.

I fully understand that it isn't as fleshed out as it could be. So if requests are made to add more testing, better linting practices, etc, let me know. I think this would be a great addition to the lib.