### PR TITLE
Fix imports for `sanic>=21.9.0`

### DIFF
--- a/examples/server/sanic/requirements.txt
+++ b/examples/server/sanic/requirements.txt
@@ -1,7 +1,8 @@
-aiofiles==0.3.0
-httptools==0.0.9
-python_engineio
-sanic==0.3.1
-six==1.10.0
-ujson==1.35
-uvloop==0.8.0
+aiofiles==0.8.0
+httptools==0.3.0
+multidict==5.2.0
+sanic==21.12.0
+sanic-routing==0.7.2
+ujson==5.1.0
+uvloop==0.16.0
+websockets==10.1

--- a/src/engineio/async_drivers/sanic.py
+++ b/src/engineio/async_drivers/sanic.py
@@ -2,8 +2,15 @@ import sys
 from urllib.parse import urlsplit
 
 try:  # pragma: no cover
+    from sanic import __version__ as sanic_version
     from sanic.response import HTTPResponse
-    from sanic.websocket import WebSocketProtocol
+
+    sanic_version = tuple(int(x) for x in sanic_version.split('.'))
+
+    if sanic_version >= (21, 9, 0):
+        from sanic.server.protocols.websocket_protocol import WebSocketProtocol
+    else:
+        from sanic.websocket import WebSocketProtocol
 except ImportError:
     HTTPResponse = None
     WebSocketProtocol = None


### PR DESCRIPTION
# Fix imports for `sanic>=21.9.0`

## Description
There was a change in imports in `sanic` from version 21.9.0, so we need to use `sanic.server.protocols.websocket_protocol.WebSocketProtocol` instead of `sanic.websocket.WebSocketProtocol` as for versions before `21.6.x` ([link to tags diff](https://github.com/sanic-org/sanic/compare/v21.6.2...v21.9.0#diff-17e2193a3741672b54b792ef620715f1d792a2268a573d78eb2dd757f38c94d8R77))

## Changes
+ Add `sanic` version check
+ Update import for `sanic>=21.9.0` to be `sanic.server.protocols.websocket_protocol.WebSocketProtocol`
+ Update sanic example code to latest LTS
