### PR TITLE
Do not decode empty text packets

### DIFF
--- a/src/engineio/packet.py
+++ b/src/engineio/packet.py
@@ -23,7 +23,10 @@ class Packet(object):
             self.binary = False
         if self.binary and self.packet_type != MESSAGE:
             raise ValueError('Binary packets can only be of type MESSAGE')
-        if encoded_packet is not None:
+
+        is_binary_encoded_packet = isinstance(encoded_packet, binary_types)
+        if (is_binary_encoded_packet and encoded_packet is not None) or \
+                encoded_packet:
             self.decode(encoded_packet)
 
     def encode(self, b64=False):

--- a/tests/common/test_packet.py
+++ b/tests/common/test_packet.py
@@ -41,6 +41,12 @@ class TestPacket(unittest.TestCase):
         pkt = packet.Packet(encoded_packet=b'4')
         assert pkt.encode() == b'4'
 
+    def test_decode_empty_packet(self):
+        pkt = packet.Packet(encoded_packet='')
+        assert pkt.data is None
+        assert not pkt.binary
+        assert pkt.encode() == '6'
+
     def test_encode_binary_packet(self):
         pkt = packet.Packet(packet.MESSAGE, data=b'\x01\x02\x03')
         assert pkt.packet_type == packet.MESSAGE

--- a/tests/common/test_packet.py
+++ b/tests/common/test_packet.py
@@ -26,8 +26,9 @@ class TestPacket(unittest.TestCase):
         assert pkt.encode() == '4text'
 
     def test_decode_text_packet(self):
-        pkt = packet.Packet(encoded_packet=b'4text')
-        assert pkt.encode() == b'4text'
+        pkt = packet.Packet(encoded_packet='4text')
+        assert not pkt.binary
+        assert pkt.encode() == '4text'
 
     def test_encode_empty_text_packet(self):
         data = ''
@@ -38,8 +39,9 @@ class TestPacket(unittest.TestCase):
         assert pkt.encode() == '4'
 
     def test_decode_empty_text_packet(self):
-        pkt = packet.Packet(encoded_packet=b'4')
-        assert pkt.encode() == b'4'
+        pkt = packet.Packet(encoded_packet='4')
+        assert not pkt.binary
+        assert pkt.encode() == '4'
 
     def test_decode_empty_packet(self):
         pkt = packet.Packet(encoded_packet='')


### PR DESCRIPTION
The commit bcd1a42f86aad12460b6eb836a5c317db55cba77 introduced the
feature to support binary packets with zero length. However, the
change introduced a bug which is fixed with this commit.

When receiving an empty packet which is not bytes (e.g. ''), the Packet class
tries to decode this (it did not previous the mentioned commit) and
throws an exception as it cannot read the first byte (which is supposed to
contain the packet type).

This behavior can occur when establishing a WebSocket connection. After the
PING packet has been sent (client.py#431), a PONG packet is expected to be
received (client.py#438). However, the WebSocket receive function can
return an empty string which now makes the packet decoding crash.
(see https://github.com/websocket-client/websocket-client/blob/d7aa5c9c244e227041764c63949d3121f84145ac/websocket/_core.py#L353-L368)
As this exception is not caught, it prevents further connection attempts.

Fixes #269