### PR TITLE
feat: allow cors_allowed_origins to be callable

### DIFF
--- a/src/engineio/asyncio_server.py
+++ b/src/engineio/asyncio_server.py
@@ -200,22 +200,19 @@ class AsyncServer(server.Server):
             origin = environ.get('HTTP_ORIGIN')
             if origin:
                 if callable(self.cors_allowed_origins):
-                    allowed_origins =  await self.cors_allowed_origins(origin)
-
-                    
+                    origin_check =  await self.cors_allowed_origins(origin)
                 else:
                     allowed_origins = self._cors_allowed_origins(environ)
                     origin_check = allowed_origins is not None and origin not in \
                             allowed_origins
 
-                    if allowed_origins is not None and origin not in \
-                            allowed_origins:
-                        self._log_error_once(
-                            origin + ' is not an accepted origin.', 'bad-origin')
-                        return await self._make_response(
-                            self._bad_request(
-                                origin + ' is not an accepted origin.'),
-                            environ)
+                if origin_check:
+                    self._log_error_once(
+                        origin + ' is not an accepted origin.', 'bad-origin')
+                    return await self._make_response(
+                        self._bad_request(
+                            origin + ' is not an accepted origin.'),
+                        environ)
 
         method = environ['REQUEST_METHOD']
         query = urllib.parse.parse_qs(environ.get('QUERY_STRING', ''))

--- a/src/engineio/asyncio_server.py
+++ b/src/engineio/asyncio_server.py
@@ -1,10 +1,7 @@
 import asyncio
 import urllib
 
-from . import exceptions
-from . import packet
-from . import server
-from . import asyncio_socket
+from . import asyncio_socket, exceptions, packet, server
 
 
 class AsyncServer(server.Server):
@@ -200,11 +197,11 @@ class AsyncServer(server.Server):
             origin = environ.get('HTTP_ORIGIN')
             if origin:
                 if callable(self.cors_allowed_origins):
-                    origin_check =  await self.cors_allowed_origins(origin)
+                    origin_check = await self.cors_allowed_origins(origin)
                 else:
                     allowed_origins = self._cors_allowed_origins(environ)
-                    origin_check = allowed_origins is not None and origin not in \
-                            allowed_origins
+                    origin_check = allowed_origins is not None and \
+                        origin not in allowed_origins
 
                 if origin_check:
                     self._log_error_once(

--- a/src/engineio/asyncio_server.py
+++ b/src/engineio/asyncio_server.py
@@ -199,17 +199,23 @@ class AsyncServer(server.Server):
             # browsers only apply CORS controls to HTTP.
             origin = environ.get('HTTP_ORIGIN')
             if origin:
-                if hasattr(self.cors_allowed_origins, '__call__'):
+                if callable(self.cors_allowed_origins):
+                    allowed_origins =  await self.cors_allowed_origins(origin)
+
                     
-                allowed_origins = self._cors_allowed_origins(environ)
-                if allowed_origins is not None and origin not in \
-                        allowed_origins:
-                    self._log_error_once(
-                        origin + ' is not an accepted origin.', 'bad-origin')
-                    return await self._make_response(
-                        self._bad_request(
-                            origin + ' is not an accepted origin.'),
-                        environ)
+                else:
+                    allowed_origins = self._cors_allowed_origins(environ)
+                    origin_check = allowed_origins is not None and origin not in \
+                            allowed_origins
+
+                    if allowed_origins is not None and origin not in \
+                            allowed_origins:
+                        self._log_error_once(
+                            origin + ' is not an accepted origin.', 'bad-origin')
+                        return await self._make_response(
+                            self._bad_request(
+                                origin + ' is not an accepted origin.'),
+                            environ)
 
         method = environ['REQUEST_METHOD']
         query = urllib.parse.parse_qs(environ.get('QUERY_STRING', ''))

--- a/src/engineio/asyncio_server.py
+++ b/src/engineio/asyncio_server.py
@@ -199,6 +199,8 @@ class AsyncServer(server.Server):
             # browsers only apply CORS controls to HTTP.
             origin = environ.get('HTTP_ORIGIN')
             if origin:
+                if hasattr(self.cors_allowed_origins, '__call__'):
+                    
                 allowed_origins = self._cors_allowed_origins(environ)
                 if allowed_origins is not None and origin not in \
                         allowed_origins:


### PR DESCRIPTION
Following this conversation https://github.com/miguelgrinberg/python-engineio/issues/264


> How about this. Let's say the cors_allowed_origins option is extended to support a callable in addition to a string. When using this option, your function will be called to decide if an origin is allowed or not. Inside your function you can use anything you want to determine if you allow the origin, including a regex match.

I'm not sure the best way to do this but here goes; check if the `cors_allowed_origins` if it is call it passing in origin. Expect the callable to return a boolean, if true allow request to go through else reject it.