### PR TITLE
Explicitly schedule coroutines as Tasks

### DIFF
--- a/src/engineio/asyncio_server.py
+++ b/src/engineio/asyncio_server.py
@@ -175,7 +175,7 @@ class AsyncServer(server.Server):
                 if sid in self.sockets:  # pragma: no cover
                     del self.sockets[sid]
         else:
-            await asyncio.wait([client.close()
+            await asyncio.wait([asyncio.create_task(client.close())
                                 for client in self.sockets.values()])
             self.sockets = {}
 


### PR DESCRIPTION
Passing coroutine objects to `wait()` directly is deprecated since Python version 3.8 and will be removed in version 3.11:

  https://docs.python.org/3/library/asyncio-task.html#asyncio.wait

This change eliminates the following `DeprecationWarning`:

```
tests/asyncio/test_asyncio_server.py::TestAsyncServer::test_disconnect_all
  /builddir/build/BUILDROOT/python-engineio-4.3.2-1.fc37.x86_64/usr/lib/python3.10/site-packages/engineio/asyncio_server.py:178: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
    await asyncio.wait([client.close()
```

on Python 3.8–3.10, and it fixes failure of:

```
tests/asyncio/test_asyncio_server.py::TestAsyncServer::test_disconnect_all
```

on Python 3.11.0b3 (pre-release).

This change is a partial fix for #279.

The implementation is based on the [example in the Python documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait).