### PR TITLE
added timeout to create_websocket()

### DIFF
--- a/src/engineio/client.py
+++ b/src/engineio/client.py
@@ -417,7 +417,8 @@ class Client(object):
         try:
             ws = websocket.create_connection(
                 websocket_url + self._get_url_timestamp(), header=headers,
-                cookie=cookies, enable_multithread=True, **extra_options)
+                cookie=cookies, enable_multithread=True, timeout=self.request_timeout, 
+                **extra_options)
         except (ConnectionError, IOError, websocket.WebSocketException):
             if upgrade:
                 self.logger.warning(


### PR DESCRIPTION
Currently the create_websocket() call doesn't have any timeout which means it can wait forever for the websocket to connect.

I made it use the same `request_timeout` as the one used for pooling connection.

This is a pretty small patch, hope it won't be a problem to merge.