### PR TITLE
Potential fixes for two issues

### DIFF
--- a/src/engineio/asyncio_client.py
+++ b/src/engineio/asyncio_client.py
@@ -581,9 +581,9 @@ class AsyncClient(client.Client):
         """
         while self.state == 'connected':
             # to simplify the timeout handling, use the maximum of the
-            # ping interval and ping timeout as timeout, with an extra 25
+            # ping interval and ping timeout as timeout, with an extra 60
             # seconds grace period
-            timeout = max(self.ping_interval, self.ping_timeout) + 25
+            timeout = max(self.ping_interval, self.ping_timeout) + 60
             packets = None
             try:
                 packets = [await asyncio.wait_for(self.queue.get(), timeout)]

--- a/src/engineio/asyncio_client.py
+++ b/src/engineio/asyncio_client.py
@@ -526,7 +526,7 @@ class AsyncClient(client.Client):
                 p = await asyncio.wait_for(
                     self.ws.receive(),
                     timeout=self.ping_interval + self.ping_timeout)
-                if not isinstance(p.data, (str, bytes)):  # pragma: no cover
+                if not isinstance(p.data, (str, bytes, int)):  # pragma: no cover
                     self.logger.warning(
                         'Server sent unexpected packet %s data %s, aborting',
                         str(p.type), str(p.data))

--- a/src/engineio/asyncio_client.py
+++ b/src/engineio/asyncio_client.py
@@ -575,9 +575,9 @@ class AsyncClient(client.Client):
         """
         while self.state == 'connected':
             # to simplify the timeout handling, use the maximum of the
-            # ping interval and ping timeout as timeout, with an extra 5
+            # ping interval and ping timeout as timeout, with an extra 25
             # seconds grace period
-            timeout = max(self.ping_interval, self.ping_timeout) + 5
+            timeout = max(self.ping_interval, self.ping_timeout) + 25
             packets = None
             try:
                 packets = [await asyncio.wait_for(self.queue.get(), timeout)]

--- a/src/engineio/asyncio_client.py
+++ b/src/engineio/asyncio_client.py
@@ -526,7 +526,9 @@ class AsyncClient(client.Client):
                 p = await asyncio.wait_for(
                     self.ws.receive(),
                     timeout=self.ping_interval + self.ping_timeout)
-                if not isinstance(p.data, (str, bytes, int)):  # pragma: no cover
+                if isinstance(p.data, int):
+                    p.data = str(p.data)
+                if not isinstance(p.data, (str, bytes)):  # pragma: no cover
                     self.logger.warning(
                         'Server sent unexpected packet %s data %s, aborting',
                         str(p.type), str(p.data))

--- a/src/engineio/asyncio_client.py
+++ b/src/engineio/asyncio_client.py
@@ -526,7 +526,7 @@ class AsyncClient(client.Client):
                 p = await asyncio.wait_for(
                     self.ws.receive(),
                     timeout=self.ping_interval + self.ping_timeout + 5)
-                if p.type == WSMsgType.CLOSED:
+                if p.type in [aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING]:
                     # Received a closed websocket message, try to close here gracefully
                     pkt = packet.Packet(packet_type=packet.CLOSE)
                     await self._receive_packet(pkt)


### PR DESCRIPTION
Hi @miguelgrinberg 

We previously talked in this issue https://github.com/miguelgrinberg/python-engineio/issues/292

Your changes to main fixed that error but I was still encountering two issues.  This PR fixes them _for me_ but I don't think this is a realistic PR to merge, I just wanted to bring this to your attention.

1. 'Server sent unexpected packet WS.MsgType.CLOSE data 0, aborting'

I would get this when the server I am communicating with would send a close packet with an int 0 data value (failing the if not isinstance(p.data, (str, bytes)) check).  

My hack checks for these 3 types of close or closing or closed packets, constructs a Packet and goes about the self._receive_packet and closing of the write loop.  It seems to work for my use-case, but I am not nearly well versed enough with the engineio internals to know what side-effects this might have (or if it is even a decent solution).


2. 'Packet queue is empty, aborting'

My client is only receiving messages from the server and it seems like on some occasions the server wouldn't send the PING msg in a timely manner, the timeout set on line 580 would expire, and my write queue would be empty.  I chose a somewhat arbitrary 60 seconds of additional padding, but if this is a decent idea it could be a parameter sent when instantiating the AsyncClient?  

As a side question, In my code I also added a concurrent loop running forever just sending a message with data of "PING" to the server every 15 seconds just to keep the write queue populated, is there a better way for a client to send a ping request to a server like this?

Thanks for all your help, feel free to discard this PR, just wanted to bring these issues to your attention and didn't know a better way to do so and share code.