### PR TITLE
Fix documentation for max_http_buffer_size

### DIFF
--- a/src/engineio/asyncio_server.py
+++ b/src/engineio/asyncio_server.py
@@ -30,9 +30,8 @@ class AsyncServer(server.Server):
     :param ping_timeout: The time in seconds that the client waits for the
                          server to respond before disconnecting. The default
                          is 20 seconds.
-    :param max_http_buffer_size: The maximum size of a message when using the
-                                 polling transport. The default is 1,000,000
-                                 bytes.
+    :param max_http_buffer_size: The maximum size of a message.  The default
+                                 is 1,000,000 bytes.
     :param allow_upgrades: Whether to allow transport upgrades or not.
     :param http_compression: Whether to compress packages when using the
                              polling transport.

--- a/src/engineio/server.py
+++ b/src/engineio/server.py
@@ -37,9 +37,8 @@ class Server(object):
     :param ping_timeout: The time in seconds that the client waits for the
                          server to respond before disconnecting. The default
                          is 20 seconds.
-    :param max_http_buffer_size: The maximum size of a message when using the
-                                 polling transport. The default is 1,000,000
-                                 bytes.
+    :param max_http_buffer_size: The maximum size of a message.  The default
+                                 is 1,000,000 bytes.
     :param allow_upgrades: Whether to allow transport upgrades or not. The
                            default is ``True``.
     :param http_compression: Whether to compress packages when using the


### PR DESCRIPTION
Due to #260, `max_http_buffer_size` is no longer just for polling transport.  Update documentation to reflect change.