### PR TITLE
Strip root_path to simplify mounting as ASGI sub app

### DIFF
--- a/src/engineio/async_drivers/asgi.py
+++ b/src/engineio/async_drivers/asgi.py
@@ -53,11 +53,14 @@ class ASGIApp:
         self.on_shutdown = on_shutdown
 
     async def __call__(self, scope, receive, send):
-        if scope['type'] in ['http', 'websocket'] and \
-                scope['path'].startswith(self.engineio_path):
+        path = scope['path']
+        if 'root_path' in scope and scope['path'].startswith(scope['root_path']):
+            path = scope['path'][len(scope['root_path']):]
+
+        if scope['type'] in ['http', 'websocket'] and path.startswith(self.engineio_path):
             await self.engineio_server.handle_request(scope, receive, send)
         else:
-            static_file = get_static_file(scope['path'], self.static_files) \
+            static_file = get_static_file(path, self.static_files) \
                 if scope['type'] == 'http' and self.static_files else None
             if scope['type'] == 'lifespan':
                 await self.lifespan(scope, receive, send)

--- a/tests/async/test_asgi.py
+++ b/tests/async/test_asgi.py
@@ -514,3 +514,30 @@ class AsgiTests(unittest.TestCase):
         environ['asgi.send'].mock.assert_called_with(
             {'type': 'websocket.close'}
         )
+
+    def test_sub_app_routing(self):
+
+        class ASGIDispatcher:
+            def __init__(self, routes):
+                self.routes = routes
+
+            async def __call__(self, scope, receive, send):
+                path = scope['path']
+                for prefix, app in self.routes.items():
+                    if path.startswith(prefix):
+                        await app(scope, receive, send)
+                        return
+                assert False, 'No route found'
+
+        other_app = AsyncMock()
+        mock_server = mock.MagicMock()
+        mock_server.handle_request = AsyncMock()
+        eio_app = async_asgi.ASGIApp(mock_server, engineio_path=None)
+        root_app = ASGIDispatcher({'/foo': other_app, '/eio': eio_app})
+        scope = {'type': 'http', 'path': '/foo/bar'}
+        _run(root_app(scope, 'receive', 'send'))
+        other_app.mock.assert_called_once_with(scope, 'receive', 'send')
+        scope = {'type': 'http', 'path': '/eio/'}
+        _run(root_app(scope, 'receive', 'send'))
+        eio_app.engineio_server.handle_request.mock.assert_called_once_with(scope, 'receive', 'send')
+


### PR DESCRIPTION
As an outcome of https://github.com/encode/starlette/discussions/2413 with newer Starlette versions we now have to provide the full path as `engineio_path` as done in the following example (via `socketio.ASGIApp(socketio_server=sio, socketio_path='/ws/socket.io')`:

```py
# pip install "starlette>=0.33.0" python-socketio uvicorn
import socketio
from starlette.applications import Starlette
from starlette.responses import HTMLResponse
from starlette.routing import Route

async def homepage(_):
    return HTMLResponse("""
    <!DOCTYPE html>
    <html>
    <head>
        <title>SocketIO Test</title>
        <script src="https://cdn.socket.io/4.7.3/socket.io.min.js"></script>
        <script type="text/javascript">
            document.addEventListener('DOMContentLoaded', (event) => {
                var basePath = window.location.pathname;
                var socket = io({ path: basePath + "ws/socket.io" });
                socket.on('msg', function(msg) {
                    document.body.innerHTML = '<h1>' + msg + '</h1>';
                });
            });
        </script>
    </head>
    <body>
        <h1>Connecting to SocketIO...</h1>
    </body>
    </html>
    """)

sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
sio_app = socketio.ASGIApp(socketio_server=sio, socketio_path='/ws/socket.io')
app = Starlette(routes=[Route("/", homepage)])
app.mount('/ws', sio_app)

@sio.on('connect')
async def handle_connect(sid, *args, **kwargs):
    await sio.emit('msg', 'Hello from Starlette!')

# Run the server with "uvicorn demo:app --reload" if your file is called demo.py
```

That works as long as the app is not itself mounted as a sub app like this:

```py
sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
sio_app = socketio.ASGIApp(socketio_server=sio, socketio_path='/ws/socket.io')
sub_app = Starlette(routes=[Route("/", homepage)])
sub_app.mount('/ws', sio_app)
app = Starlette()
app.mount('/sub', sub_app)
```

The above code fails because the frontend tries to connect to `/sub/ws/socket.io` but engineio simply checks if the `scope['path']` starts with `self.engineio_path`.

This pull request fixes this by making python-engineio aware of ASGIs `scope['root_path']`.  It strips the root path from `scope['path']` before checking whether it matches `self.engineio_path`. This allows us to provide the relative `socketio_path` (which is then passed to engineio as `engineio_path`:

```py
sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
sio_app = socketio.ASGIApp(socketio_server=sio, socketio_path='socket.io')
sub_app = Starlette(routes=[Route("/", homepage)])
sub_app.mount('/ws', sio_app)
app = Starlette()
app.mount('/sub', sub_app)
```

The issue came up in https://github.com/zauberzeug/nicegui/issues/2515 and https://github.com/zauberzeug/nicegui/issues/2468. It should be fixed in python-enginio in my opinion to better support "ASGI sub app mounting" for everyone using python-engineio.