### PR TITLE
Add automatic path handling to ASGIApp

### DIFF
--- a/src/engineio/async_drivers/asgi.py
+++ b/src/engineio/async_drivers/asgi.py
@@ -1,9 +1,9 @@
+import re
 import os
 import sys
 import asyncio
 
 from engineio.static_files import get_static_file
-
 
 class ASGIApp:
     """ASGI application middleware for Engine.IO.
@@ -45,25 +45,33 @@ class ASGIApp:
     """
     def __init__(self, engineio_server, other_asgi_app=None,
                  static_files=None, engineio_path='engine.io',
-                 on_startup=None, on_shutdown=None):
+                 on_startup=None, on_shutdown=None, automatic_path_handling=True):
         self.engineio_server = engineio_server
         self.other_asgi_app = other_asgi_app
         self.engineio_path = engineio_path
+        self.automatic_path_handling = automatic_path_handling
         if self.engineio_path is not None:
+            self.engineio_path = '/' + self.engineio_path.lstrip('/')
+            if self.automatic_path_handling:
+                self.engineio_path = re.sub(r'/+', '/', self.engineio_path)
+                if self.engineio_path.endswith('/'):
+                    self.engineio_path = self.engineio_path.rstrip('/')
             if not self.engineio_path.startswith('/'):
                 self.engineio_path = '/' + self.engineio_path
-            if not self.engineio_path.endswith('/'):
-                self.engineio_path += '/'
         self.static_files = static_files or {}
         self.on_startup = on_startup
         self.on_shutdown = on_shutdown
 
     async def __call__(self, scope, receive, send):
+        if self.automatic_path_handling and 'path' in scope:
+            if scope['path'].endswith('/'):
+                scope['path'] = scope['path'].rstrip('/')
         if scope['type'] == 'lifespan':
             await self.lifespan(scope, receive, send)
         elif scope['type'] in ['http', 'websocket'] and (
                 self.engineio_path is None
-                or scope['path'].startswith(self.engineio_path)):
+                or scope['path'] == self.engineio_path
+                or '/' == self.engineio_path):
             await self.engineio_server.handle_request(scope, receive, send)
         else:
             static_file = get_static_file(scope['path'], self.static_files) \


### PR DESCRIPTION
Hello! It's me again, I took advice of what you said at #360 

> The default behavior should be that you provide your endpoint with or without trailing slash, and the server accepts the endpoint with or without trailing slash. This should work in pretty much all cases without any need to add configuration. I think just doing this would be an improvement.

The code I propose achieves the following:

With the `automatic_path_handling` parameter as **True**

`foo` results in `/foo`

`foo/foobar` results in `/foo/foobar`

`///foo` results in  `/foo`

`///foo///` results in `/foo`

`////foo/////foobar///` results in `/foo/foobar`

`''` (empty string) results in `/`

`/` results in `/`

With the automatic_path_handling as **False**

`foo` results in `/foo`

`foo/` results in `/foo/`

`/foo/foobar/` results in `/foo/foobar/`

`//foo///` results in `/foo///`

`///foo///foobar////////` results in `/foo///foobar////////`

`''` (empty string) results in `/`

`/` results in `/`

I'm still not sure on whether removing the extra slashes such as the browsers do is right or not, because at least Postman can connect with those weird paths.

Other thing is that even with `automatic_path_handling` as **False**, the leading slashes are removed because a path with multiple leading slashes doesn't make much sense.

I think you can enlighten me on what to do exactly when the option is set to **False**, this pull requests aims more for advice than for a merge right now.

Having in mind that:

> When you remove the trailing slash path matching using startswith() doesn't work anymore.

I changed the behaviour of `__call__`  to trim the trailing slash when the ASGI middleware is called and the `automatic_path_handling` parameter is set to True (which should be the default value).

This way we can match the pattern using `scope['path'] == self.engineio_path` instead of `scope['path'].startswith(self.engineio_path)`, this allows the routes to work with or without the trailing slash and without other possible paths interfering, for example

`/foo` and `/foo/` both work, but `/foobar` doesn't.

If you think this approach could be beneficial, I'd be happy to further refine and extend it to the WSGIApp as well. Your feedback would be greatly appreciated, as it will help me determine whether this change aligns with the project goals. If it’s not something that's being considered at this time, please let me know, and I'll focus my efforts elsewhere and just use a custom wheel in my projects to have this functionality.

**Note**: This change is useful in the case I described at #359 because I couldn't get an ASGI middleware to work to trim the trailing slash in the `socketio_app` while keeping the `other_asgi_app` working correctly.