### PR TITLE
Pass additional args to callable option cors_allowed_origins

### DIFF
--- a/src/engineio/base_server.py
+++ b/src/engineio/base_server.py
@@ -282,21 +282,22 @@ class BaseServer:
                 'response': message.encode('utf-8')}
 
     def _cors_allowed_origins(self, environ):
-        default_origins = []
-        if 'wsgi.url_scheme' in environ and 'HTTP_HOST' in environ:
-            default_origins.append('{scheme}://{host}'.format(
-                scheme=environ['wsgi.url_scheme'], host=environ['HTTP_HOST']))
-            if 'HTTP_X_FORWARDED_PROTO' in environ or \
-                    'HTTP_X_FORWARDED_HOST' in environ:
-                scheme = environ.get(
-                    'HTTP_X_FORWARDED_PROTO',
-                    environ['wsgi.url_scheme']).split(',')[0].strip()
-                default_origins.append('{scheme}://{host}'.format(
-                    scheme=scheme, host=environ.get(
-                        'HTTP_X_FORWARDED_HOST', environ['HTTP_HOST']).split(
-                            ',')[0].strip()))
         if self.cors_allowed_origins is None:
-            allowed_origins = default_origins
+            allowed_origins = []
+            if 'wsgi.url_scheme' in environ and 'HTTP_HOST' in environ:
+                allowed_origins.append('{scheme}://{host}'.format(
+                    scheme=environ['wsgi.url_scheme'],
+                    host=environ['HTTP_HOST']))
+                if 'HTTP_X_FORWARDED_PROTO' in environ or \
+                        'HTTP_X_FORWARDED_HOST' in environ:
+                    scheme = environ.get(
+                        'HTTP_X_FORWARDED_PROTO',
+                        environ['wsgi.url_scheme']).split(',')[0].strip()
+                    allowed_origins.append('{scheme}://{host}'.format(
+                        scheme=scheme, host=environ.get(
+                            'HTTP_X_FORWARDED_HOST',
+                            environ['HTTP_HOST']).split(
+                                ',')[0].strip()))
         elif self.cors_allowed_origins == '*':
             allowed_origins = None
         elif isinstance(self.cors_allowed_origins, str):
@@ -304,12 +305,10 @@ class BaseServer:
         elif callable(self.cors_allowed_origins):
             origin = environ.get('HTTP_ORIGIN')
             try:
-                is_allowed = self.cors_allowed_origins(
-                    origin, default_origins=default_origins, environ=environ)
+                is_allowed = self.cors_allowed_origins(origin, environ)
             except TypeError:
                 is_allowed = self.cors_allowed_origins(origin)
-            allowed_origins = [origin] \
-                if is_allowed else []
+            allowed_origins = [origin] if is_allowed else []
         else:
             allowed_origins = self.cors_allowed_origins
         return allowed_origins

--- a/src/engineio/base_server.py
+++ b/src/engineio/base_server.py
@@ -303,8 +303,13 @@ class BaseServer:
             allowed_origins = [self.cors_allowed_origins]
         elif callable(self.cors_allowed_origins):
             origin = environ.get('HTTP_ORIGIN')
+            try:
+                is_allowed = self.cors_allowed_origins(
+                    origin, default_origins=default_origins, environ=environ)
+            except TypeError:
+                is_allowed = self.cors_allowed_origins(origin)
             allowed_origins = [origin] \
-                if self.cors_allowed_origins(origin) else []
+                if is_allowed else []
         else:
             allowed_origins = self.cors_allowed_origins
         return allowed_origins


### PR DESCRIPTION
If option cors_allowed_origins is callable, pass additional args for default_origins and environ to it. Use try-except to still allow usage of a callback without these additional args.

Background:
For our project, we need to dynamically check for origins, which are allowed _additionally_ to the default ones (especially the same origin).

The try-except is just a proposal to avoid a breaking change.
