### PR TITLE
Fix tricky issue in handling of websocket.receive messages

### DIFF
--- a/src/engineio/async_drivers/asgi.py
+++ b/src/engineio/async_drivers/asgi.py
@@ -280,9 +280,9 @@ class WebSocket:  # pragma: no cover
         event = await self.asgi_receive()
         if event['type'] != 'websocket.receive':
             raise OSError()
-        if 'bytes' in event:
+        if event.get('bytes', None) is not None:
             return event['bytes']
-        elif 'text' in event:
+        elif event.get('text', None) is not None:
             return event['text']
         else:  # pragma: no cover
             raise OSError()


### PR DESCRIPTION
Hi — I was debugging a customer issue for work at Modal (modal.com) and discovered that the python engine.io implementation behaves [slightly differently from the ASGI spec](https://asgi.readthedocs.io/en/latest/specs/www.html#receive-receive-event), which suggests that:

> Exactly one of bytes or text must be non-None. One or both keys may be present, however.

The Python engineio client fails connection on Modal currently because it gets a dict:

```
{'type': 'websocket.send', 'bytes': None, 'text': '40{"sid":"gK4jeac7mjv1pc6kAAAB"}'}
```

But it checks for presence with `'bytes' in event`, rather than `event.get('bytes') is not None`.

This is a quick fix for the issue — let me know if this makes sense or if you'd want me to help add a test as well!