### PR TITLE
Fixing miguelgrinberg/python-engineio#403.

### DIFF
--- a/src/engineio/async_client.py
+++ b/src/engineio/async_client.py
@@ -202,7 +202,7 @@ class AsyncClient(base_client.BaseClient):
     def create_queue(self):
         """Create a queue object."""
         q = asyncio.Queue()
-        q.Empty = asyncio.QueueEmpty
+        self.queue_empty_exc = asyncio.QueueEmpty
         return q
 
     def create_event(self):
@@ -624,7 +624,7 @@ class AsyncClient(base_client.BaseClient):
             packets = None
             try:
                 packets = [await asyncio.wait_for(self.queue.get(), timeout)]
-            except (self.queue.Empty, asyncio.TimeoutError):
+            except (self.queue_empty_exc, asyncio.TimeoutError):
                 self.logger.error('packet queue is empty, aborting')
                 break
             except asyncio.CancelledError:  # pragma: no cover
@@ -636,7 +636,7 @@ class AsyncClient(base_client.BaseClient):
                 while True:
                     try:
                         packets.append(self.queue.get_nowait())
-                    except self.queue.Empty:
+                    except self.queue_empty_exc:
                         break
                     if packets[-1] is None:
                         packets = packets[:-1]

--- a/src/engineio/client.py
+++ b/src/engineio/client.py
@@ -163,7 +163,7 @@ class Client(base_client.BaseClient):
     def create_queue(self, *args, **kwargs):
         """Create a queue object."""
         q = queue.Queue(*args, **kwargs)
-        q.Empty = queue.Empty
+        self.queue_empty_exc = queue.Empty
         return q
 
     def create_event(self, *args, **kwargs):
@@ -566,7 +566,7 @@ class Client(base_client.BaseClient):
             packets = None
             try:
                 packets = [self.queue.get(timeout=timeout)]
-            except self.queue.Empty:
+            except self.queue_empty_exc:
                 self.logger.error('packet queue is empty, aborting')
                 break
             if packets == [None]:
@@ -576,7 +576,7 @@ class Client(base_client.BaseClient):
                 while True:
                     try:
                         packets.append(self.queue.get(block=False))
-                    except self.queue.Empty:
+                    except self.queue_empty_exc:
                         break
                     if packets[-1] is None:
                         packets = packets[:-1]

--- a/tests/async/test_client.py
+++ b/tests/async/test_client.py
@@ -225,7 +225,7 @@ class TestAsyncClient:
     async def test_create_queue(self):
         c = async_client.AsyncClient()
         q = c.create_queue()
-        with pytest.raises(q.Empty):
+        with pytest.raises(c.queue_empty_exc):
             q.get_nowait()
 
     async def test_create_event(self):
@@ -1200,7 +1200,7 @@ class TestAsyncClient:
         c.ping_interval = 1
         c.ping_timeout = 2
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(side_effect=RuntimeError)
         await c._write_loop()
         c.queue.get.assert_awaited_once_with()
@@ -1213,7 +1213,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[
                 packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
@@ -1244,7 +1244,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[
                 packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
@@ -1285,7 +1285,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[
                 packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
@@ -1322,7 +1322,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[packet.Packet(packet.MESSAGE, {'foo': 'bar'})]
         )
@@ -1350,7 +1350,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[packet.Packet(packet.MESSAGE, {'foo': 'bar'})]
         )
@@ -1379,7 +1379,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'websocket'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[
                 packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
@@ -1401,7 +1401,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'websocket'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[
                 packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
@@ -1431,7 +1431,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'websocket'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[packet.Packet(packet.MESSAGE, b'foo'), RuntimeError]
         )
@@ -1450,7 +1450,7 @@ class TestAsyncClient:
         c.ping_timeout = 2
         c.current_transport = 'websocket'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get = mock.AsyncMock(
             side_effect=[
                 packet.Packet(packet.MESSAGE, {'foo': 'bar'}),

--- a/tests/async/test_socket.py
+++ b/tests/async/test_socket.py
@@ -40,7 +40,7 @@ class TestSocket:
 
         def create_queue(*args, **kwargs):
             queue = asyncio.Queue(*args, **kwargs)
-            queue.Empty = asyncio.QueueEmpty
+            queue.Empty = asyncio.QueueEmpty # this is not actually necessary
             return queue
 
         mock_server.start_background_task = bg_task

--- a/tests/common/run_gevent_tests.py
+++ b/tests/common/run_gevent_tests.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import gevent.monkey
+gevent.monkey.patch_all()
+
+import pytest
+import sys
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([
+        '-p', 'no:logging',
+        '--cov=engineio', 
+        '--cov-branch', 
+        '--cov-report=term-missing', 
+        '--cov-report=xml',
+        # Skip tests containing 'gevent' in tests/common/test_server.py
+        # as these are all stub tests and conflict with monkey patching.
+        '-k', 'not (gevent and test_server)',
+    ]))

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -289,7 +289,7 @@ class TestClient:
     def test_create_queue(self):
         c = client.Client()
         q = c.create_queue()
-        with pytest.raises(q.Empty):
+        with pytest.raises(c.queue_empty_exc):
             q.get(timeout=0.01)
 
     def test_create_event(self):
@@ -1499,7 +1499,7 @@ class TestClient:
         c.ping_interval = 1
         c.ping_timeout = 2
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = RuntimeError
         c._write_loop()
         c.queue.get.assert_called_once_with(timeout=7)
@@ -1512,7 +1512,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
             RuntimeError,
@@ -1541,7 +1541,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
             packet.Packet(packet.PING),
@@ -1576,7 +1576,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
             packet.Packet(packet.PING),
@@ -1610,7 +1610,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
             RuntimeError,
@@ -1639,7 +1639,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'polling'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
             RuntimeError,
@@ -1668,7 +1668,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'websocket'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
             RuntimeError,
@@ -1688,7 +1688,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'websocket'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
             packet.Packet(packet.PING),
@@ -1712,7 +1712,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'websocket'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, b'foo'),
             RuntimeError,
@@ -1732,7 +1732,7 @@ class TestClient:
         c.ping_timeout = 2
         c.current_transport = 'websocket'
         c.queue = mock.MagicMock()
-        c.queue.Empty = RuntimeError
+        c.queue_empty_exc = RuntimeError
         c.queue.get.side_effect = [
             packet.Packet(packet.MESSAGE, {'foo': 'bar'}),
             RuntimeError,

--- a/tox.ini
+++ b/tox.ini
@@ -41,3 +41,11 @@ allowlist_externals=
     make
 commands=
     make html
+
+[testenv:gevent]
+deps = 
+    {[testenv]deps}
+    gevent=={env:GEVENT_VERSION:25.4.1}
+commands =
+    pip install -e .
+    python tests/common/run_gevent_tests.py


### PR DESCRIPTION
# Fixes
This is a minimal fix for #403.

# Changes
1. Storing the queue empty exception in the client instance, so that we no longer require the ability to add attributes to queue.Queue. This solves the problem introduced by gevent 25.4.1, where the monkey-patched queue.Queue becomes Cython-based and no longer allows adding attributes.
2. Introducing a class `MockQueue` in `tests/common/test_socket.py` as the queue provider for the mock server, so that later tests that modify its `.join` method can run.
3. Adding a new test environment for checking compatibility with different versions of gevent. This can be invoked as `tox -e gevent`. This will first monkey-patch everything, then run the tests described in the main `[testenv]` environment, with the exception that all tests inside `tests/common/test_server.py` having `gevent` in their names will be skipped (as these tests interfere with monkey-patching). An optional env var called `GEVENT_VERSION` (defaults to "25.4.1") can be passed in to specify the version of gevent to be used.

# Tests Done
1. `tox -e py` (default testing, without monkey patching) and `tox -e gevent` both pass.
`GEVENT_VERSION=24.11.1 tox -e gevent` also passes.
2. Performance tests (`tests/performance/run.sh`) show no noticeable difference. 
Results from my local runs are as follows:
> 
> Before patching:
> 
>> text_packet: 2022430 packets processed.
>> binary_packet: 16274018 packets processed.
>> binary_b64_packet: 9206001 packets processed.
>> json_packet: 1840093 packets processed.
>> payload: 867860 payloads processed.
>> server_receive: 969609 packets received.
> 
> After patching:
> 
>> text_packet: 2106527 packets processed.
>> binary_packet: 16469943 packets processed.
>> binary_b64_packet: 9495183 packets processed.
>> json_packet: 1817357 packets processed.
>> payload: 851590 payloads processed.
>> server_receive: 960605 packets received.
