### PR TITLE
Support set cors allowed origins as `['*']`

### DIFF
--- a/src/engineio/async_server.py
+++ b/src/engineio/async_server.py
@@ -56,8 +56,8 @@ class AsyncServer(base_server.BaseServer):
     :param cors_allowed_origins: Origin or list of origins that are allowed to
                                  connect to this server. Only the same origin
                                  is allowed by default. Set this argument to
-                                 ``'*'`` to allow all origins, or to ``[]`` to
-                                 disable CORS handling.
+                                 ``'*'`` or ``['*']`` to allow all origins, or
+                                 to ``[]`` to disable CORS handling.
     :param cors_credentials: Whether credentials (cookies, authentication) are
                              allowed in requests to this server.
     :param logger: To enable logging set to ``True`` or pass a logger object to

--- a/src/engineio/base_server.py
+++ b/src/engineio/base_server.py
@@ -310,7 +310,10 @@ class BaseServer:
                 is_allowed = self.cors_allowed_origins(origin)
             allowed_origins = [origin] if is_allowed else []
         else:
-            allowed_origins = self.cors_allowed_origins
+            if '*' in self.cors_allowed_origins:
+                allowed_origins = None
+            else:
+                allowed_origins = self.cors_allowed_origins
         return allowed_origins
 
     def _cors_headers(self, environ):

--- a/src/engineio/server.py
+++ b/src/engineio/server.py
@@ -54,8 +54,8 @@ class Server(base_server.BaseServer):
     :param cors_allowed_origins: Origin or list of origins that are allowed to
                                  connect to this server. Only the same origin
                                  is allowed by default. Set this argument to
-                                 ``'*'`` to allow all origins, or to ``[]`` to
-                                 disable CORS handling.
+                                 ``'*'`` or ``['*']`` to allow all origins, or
+                                 to ``[]`` to disable CORS handling.
     :param cors_credentials: Whether credentials (cookies, authentication) are
                              allowed in requests to this server. The default
                              is ``True``.

--- a/tests/async/test_server.py
+++ b/tests/async/test_server.py
@@ -454,12 +454,25 @@ class TestAsyncServer:
         assert ('Access-Control-Allow-Origin', '*') not in headers
 
     @mock.patch('importlib.import_module')
-    async def test_connect_cors_all_origins(self, import_module):
+    async def test_connect_str_cors_all_origins(self, import_module):
         a = self.get_async_mock(
             {'REQUEST_METHOD': 'GET', 'QUERY_STRING': '', 'HTTP_ORIGIN': 'foo'}
         )
         import_module.side_effect = [a]
         s = async_server.AsyncServer(cors_allowed_origins='*')
+        await s.handle_request('request')
+        assert a._async['make_response'].call_args[0][0] == '200 OK'
+        headers = a._async['make_response'].call_args[0][1]
+        assert ('Access-Control-Allow-Origin', 'foo') in headers
+        assert ('Access-Control-Allow-Credentials', 'true') in headers
+
+    @mock.patch('importlib.import_module')
+    async def test_connect_list_cors_all_origins(self, import_module):
+        a = self.get_async_mock(
+            {'REQUEST_METHOD': 'GET', 'QUERY_STRING': '', 'HTTP_ORIGIN': 'foo'}
+        )
+        import_module.side_effect = [a]
+        s = async_server.AsyncServer(cors_allowed_origins=['*'])
         await s.handle_request('request')
         assert a._async['make_response'].call_args[0][0] == '200 OK'
         headers = a._async['make_response'].call_args[0][1]
@@ -564,10 +577,21 @@ class TestAsyncServer:
             assert header[0] != 'Access-Control-Allow-Origin'
 
     @mock.patch('importlib.import_module')
-    async def test_connect_cors_all_no_origin(self, import_module):
+    async def test_connect_str_cors_all_no_origin(self, import_module):
         a = self.get_async_mock({'REQUEST_METHOD': 'GET', 'QUERY_STRING': ''})
         import_module.side_effect = [a]
         s = async_server.AsyncServer(cors_allowed_origins='*')
+        await s.handle_request('request')
+        assert a._async['make_response'].call_args[0][0] == '200 OK'
+        headers = a._async['make_response'].call_args[0][1]
+        for header in headers:
+            assert header[0] != 'Access-Control-Allow-Origin'
+
+    @mock.patch('importlib.import_module')
+    async def test_connect_list_cors_all_no_origin(self, import_module):
+        a = self.get_async_mock({'REQUEST_METHOD': 'GET', 'QUERY_STRING': ''})
+        import_module.side_effect = [a]
+        s = async_server.AsyncServer(cors_allowed_origins=['*'])
         await s.handle_request('request')
         assert a._async['make_response'].call_args[0][0] == '200 OK'
         headers = a._async['make_response'].call_args[0][1]

--- a/tests/common/test_server.py
+++ b/tests/common/test_server.py
@@ -615,8 +615,22 @@ class TestServer:
         assert ('Access-Control-Allow-Origin', 'c') not in headers
         assert ('Access-Control-Allow-Origin', '*') not in headers
 
-    def test_connect_cors_headers_all_origins(self):
+    def test_connect_str_cors_headers_all_origins(self):
         s = server.Server(cors_allowed_origins='*')
+        environ = {
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': 'EIO=4',
+            'HTTP_ORIGIN': 'foo',
+        }
+        start_response = mock.MagicMock()
+        s.handle_request(environ, start_response)
+        assert start_response.call_args[0][0] == '200 OK'
+        headers = start_response.call_args[0][1]
+        assert ('Access-Control-Allow-Origin', 'foo') in headers
+        assert ('Access-Control-Allow-Credentials', 'true') in headers
+
+    def test_connect_list_cors_headers_all_origins(self):
+        s = server.Server(cors_allowed_origins=['*'])
         environ = {
             'REQUEST_METHOD': 'GET',
             'QUERY_STRING': 'EIO=4',
@@ -762,8 +776,17 @@ class TestServer:
         for header in headers:
             assert header[0] != 'Access-Control-Allow-Origin'
 
-    def test_connect_cors_all_no_origin(self):
+    def test_connect_str_cors_all_no_origin(self):
         s = server.Server(cors_allowed_origins='*')
+        environ = {'REQUEST_METHOD': 'GET', 'QUERY_STRING': 'EIO=4'}
+        start_response = mock.MagicMock()
+        s.handle_request(environ, start_response)
+        headers = start_response.call_args[0][1]
+        for header in headers:
+            assert header[0] != 'Access-Control-Allow-Origin'
+
+    def test_connect_list_cors_all_no_origin(self):
+        s = server.Server(cors_allowed_origins=['*'])
         environ = {'REQUEST_METHOD': 'GET', 'QUERY_STRING': 'EIO=4'}
         start_response = mock.MagicMock()
         s.handle_request(environ, start_response)


### PR DESCRIPTION
Hi, @miguelgrinberg 

This change will be compatible with the following:
https://github.com/encode/starlette/blob/78da9b9e218ab289117df7d62aee200ed4c59617/starlette/middleware/cors.py#L19

The same will apply to fastapi, which helps synchronize the setup of server and ws cors allowed origins.