### PR TITLE
Fix Cookie Parsing in WebSocket Connections

### DIFF
--- a/src/engineio/async_client.py
+++ b/src/engineio/async_client.py
@@ -12,6 +12,7 @@ from . import base_client
 from . import exceptions
 from . import packet
 from . import payload
+from . import client_cookies
 
 async_signal_handler_set = False
 
@@ -319,14 +320,12 @@ class AsyncClient(base_client.BaseClient):
 
         # extract any new cookies passed in a header so that they can also be
         # sent the the WebSocket route
-        cookies = {}
         for header, value in headers.items():
             if header.lower() == 'cookie':
-                cookies = dict(
-                    [cookie.split('=', 1) for cookie in value.split('; ')])
+                cookie_dict = client_cookies.decode_cookie_string(value)
+                self.http.cookie_jar.update_cookies(cookie_dict)
                 del headers[header]
                 break
-        self.http.cookie_jar.update_cookies(cookies)
 
         extra_options = {'timeout': self.request_timeout}
         if not self.ssl_verify:

--- a/src/engineio/client_cookies.py
+++ b/src/engineio/client_cookies.py
@@ -1,0 +1,20 @@
+from http.cookies import SimpleCookie
+
+
+def decode_cookie_string(cookie_string: str) -> dict:
+    c = SimpleCookie()
+    c.load(cookie_string)
+    return {
+        morsel.key: morsel.value for morsel in c.values()
+    }
+
+
+def encode_cookie_dict(cookie_dict: dict) -> str:
+    c = SimpleCookie()
+    c.load(cookie_dict)
+    result = []
+    for morsel in c.values():
+        result.append(
+            "%s=%s" % (morsel.key, morsel.coded_value)
+        )
+    return '; '.join(result)

--- a/tests/async/test_client.py
+++ b/tests/async/test_client.py
@@ -705,7 +705,7 @@ class TestAsyncClient:
         c.on('connect', on_connect)
         await c.connect(
             'ws://foo',
-            headers={'Cookie': 'key=value; key2=value2; key3="value3="'},
+            headers={'Cookie': 'key=value; key2=value2; key3="value3=";'},
             transports=['websocket'],
         )
         c.http.ws_connect.assert_awaited_once_with(
@@ -714,7 +714,7 @@ class TestAsyncClient:
             timeout=5,
         )
         c.http.cookie_jar.update_cookies.assert_called_once_with(
-            {'key': 'value', 'key2': 'value2', 'key3': '"value3="'}
+            {'key': 'value', 'key2': 'value2', 'key3': 'value3='}
         )
 
     @mock.patch('engineio.client.time.time', return_value=123.456)
@@ -745,7 +745,7 @@ class TestAsyncClient:
         c.on('connect', on_connect)
         await c.connect(
             'ws://foo',
-            headers={'Foo': 'Bar', 'Cookie': 'key3=value3'},
+            headers={'Foo': 'Bar', 'Cookie': 'key3="value3="'},
             transports=['websocket'],
         )
         c.http.ws_connect.assert_awaited_once_with(
@@ -754,7 +754,7 @@ class TestAsyncClient:
             timeout=5,
         )
         c.http.cookie_jar.update_cookies.assert_called_once_with(
-            {'key3': 'value3'}
+            {'key3': 'value3='}
         )
 
     async def test_websocket_upgrade_no_pong(self):

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -572,7 +572,7 @@ class TestClient:
         create_connection.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=4&t=123.456',
             header={'Foo': 'Bar'},
-            cookie=None,
+            cookie='',
             enable_multithread=True,
             timeout=5
         )
@@ -592,7 +592,7 @@ class TestClient:
         create_connection.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=4&t=123.456',
             header={'Foo': 'Bar', 'Baz': 'Qux'},
-            cookie=None,
+            cookie='',
             enable_multithread=True,
             timeout=10
         )
@@ -613,7 +613,7 @@ class TestClient:
         create_connection.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=4&t=123.456',
             header={'Foo': 'Bar'},
-            cookie=None,
+            cookie='',
             enable_multithread=True,
             timeout=5
         )
@@ -632,7 +632,7 @@ class TestClient:
         create_connection.assert_called_once_with(
             'ws://foo/engine.io/?transport=websocket&EIO=4&sid=123&t=123.456',
             header={},
-            cookie=None,
+            cookie='',
             enable_multithread=True,
             timeout=5
         )
@@ -681,7 +681,7 @@ class TestClient:
         assert len(create_connection.call_args_list) == 1
         assert create_connection.call_args[1] == {
             'header': {},
-            'cookie': None,
+            'cookie': '',
             'enable_multithread': True,
             'timeout': 5,
         }
@@ -723,7 +723,7 @@ class TestClient:
         assert len(create_connection.call_args_list) == 1
         assert create_connection.call_args[1] == {
             'header': {},
-            'cookie': None,
+            'cookie': '',
             'enable_multithread': True,
             'timeout': 5,
             'sslopt': {'cert_reqs': ssl.CERT_NONE},
@@ -745,7 +745,7 @@ class TestClient:
         http.cookies[0].name = 'key'
         http.cookies[0].value = 'value'
         http.cookies[1].name = 'key2'
-        http.cookies[1].value = 'value2'
+        http.cookies[1].value = '"value2"'
         http.auth = None
         http.proxies = None
         http.cert = None
@@ -761,7 +761,7 @@ class TestClient:
         assert len(create_connection.call_args_list) == 1
         assert create_connection.call_args[1] == {
             'header': {},
-            'cookie': 'key=value; key2=value2',
+            'cookie': 'key=value; key2="\\"value2\\""',
             'enable_multithread': True,
             'timeout': 5,
         }


### PR DESCRIPTION

Engine.IO clients fail to handle quoted cookie values when upgrading to WebSocket connections, causing connection issues with applications that use cookies containing spaces or special characters.

### Specific Issues:

`AsyncClient`: 
1. Manual string splitting crashes on name="Alice; Bob"
2. Misbehavior in some cases.
```python
input_cookie_string = 'c1=v1; c2="v2"'
# This cookie will parses like:
output_cookie_dict = {
    'c1': 'v1',
    'c2': '"v2"'
}
# Correct form is:
output_cookie_dict = {
    'c1': 'v1',
    'c2': 'v2'
}
``` 
`Sync client`:
1. Inconsistent cookie encoding between HTTP and WebSocket transports
2. Misbehavior in some cases.
```python
cookie_dict = {
    'foo': 'bar',
    'fooo': '"bar"'
}

# If we pass it to http_session it will take effect in cookie header like this
cookie_header = 'foo=bar; fooo="bar"'

# But correct form is:
cookie_header = 'foo=bar; fooo=\\"bar\\"'

```
### Solution:

Replace manual cookie parsing with Python's standard `http.cookies.SimpleCookie`

1. Added client_cookies.py utility module
2. Fixed async client cookie header parsing
3. Fixed sync client cookie encoding consistency
4. Updated test cases to reflect correct behavior

I’m open to feedback and ready to address any issues or improvements in this PR.