### PR TITLE
[RFC] Remove logger configuration from client/server classes

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -336,27 +336,6 @@ Or for ``asyncio``::
 The single argument passed to the method is the number of seconds to sleep
 for.
 
-Debugging and Troubleshooting
------------------------------
-
-To help you debug issues, the server can be configured to output logs to the
-terminal::
-
-    import engineio
-
-    # standard Python
-    eio = engineio.Server(logger=True)
-
-    # asyncio
-    eio = engineio.AsyncServer(logger=True)
-
-The ``logger`` argument can be set to ``True`` to output logs to ``stderr``, or
-to an object compatible with Python's ``logging`` package where the logs should
-be emitted to. A value of ``False`` disables logging.
-
-Logging can help identify the cause of connection problems, 400 responses,
-bad performance and other issues.
-
 .. _deployment-strategies:
 
 Deployment Strategies

--- a/src/engineio/async_client.py
+++ b/src/engineio/async_client.py
@@ -50,10 +50,8 @@ class AsyncClient(base_client.BaseClient):
     for websocket and long-polling transports, compatible with the asyncio
     framework on Python 3.5 or newer.
 
-    :param logger: To enable logging set to ``True`` or pass a logger object to
-                   use. To disable logging set to ``False``. The default is
-                   ``False``. Note that fatal errors are logged even when
-                   ``logger`` is ``False``.
+    :param logger: Logger instance to use.
+    :type logger: logging.Logger, optional
     :param json: An alternative json module to use for encoding and decoding
                  packets. Custom json modules must have ``dumps`` and ``loads``
                  functions that are compatible with the standard library

--- a/src/engineio/async_server.py
+++ b/src/engineio/async_server.py
@@ -60,9 +60,8 @@ class AsyncServer(base_server.BaseServer):
                                  to ``[]`` to disable CORS handling.
     :param cors_credentials: Whether credentials (cookies, authentication) are
                              allowed in requests to this server.
-    :param logger: To enable logging set to ``True`` or pass a logger object to
-                   use. To disable logging set to ``False``. Note that fatal
-                   errors are logged even when ``logger`` is ``False``.
+    :param logger: Logger instance to use.
+    :type logger: logging.Logger, optional
     :param json: An alternative json module to use for encoding and decoding
                  packets. Custom json modules must have ``dumps`` and ``loads``
                  functions that are compatible with the standard library

--- a/src/engineio/client.py
+++ b/src/engineio/client.py
@@ -1,6 +1,5 @@
 from base64 import b64encode
 from http.cookies import SimpleCookie
-import logging
 import queue
 import ssl
 import threading
@@ -21,8 +20,6 @@ from . import exceptions
 from . import packet
 from . import payload
 
-default_logger = logging.getLogger('engineio.client')
-
 
 class Client(base_client.BaseClient):
     """An Engine.IO client.
@@ -30,10 +27,8 @@ class Client(base_client.BaseClient):
     This class implements a fully compliant Engine.IO web client with support
     for websocket and long-polling transports.
 
-    :param logger: To enable logging set to ``True`` or pass a logger object to
-                   use. To disable logging set to ``False``. The default is
-                   ``False``. Note that fatal errors are logged even when
-                   ``logger`` is ``False``.
+    :param logger: Logger instance to use.
+    :type logger: logging.Logger, optional
     :param json: An alternative json module to use for encoding and decoding
                  packets. Custom json modules must have ``dumps`` and ``loads``
                  functions that are compatible with the standard library

--- a/src/engineio/server.py
+++ b/src/engineio/server.py
@@ -1,12 +1,9 @@
-import logging
 import urllib
 
 from . import base_server
 from . import exceptions
 from . import packet
 from . import socket
-
-default_logger = logging.getLogger('engineio.server')
 
 
 class Server(base_server.BaseServer):
@@ -59,10 +56,8 @@ class Server(base_server.BaseServer):
     :param cors_credentials: Whether credentials (cookies, authentication) are
                              allowed in requests to this server. The default
                              is ``True``.
-    :param logger: To enable logging set to ``True`` or pass a logger object to
-                   use. To disable logging set to ``False``. The default is
-                   ``False``. Note that fatal errors are logged even when
-                   ``logger`` is ``False``.
+    :param logger: Logger instance to use.
+    :type logger: logging.Logger, optional
     :param json: An alternative json module to use for encoding and decoding
                  packets. Custom json modules must have ``dumps`` and ``loads``
                  functions that are compatible with the standard library

--- a/tests/async/test_server.py
+++ b/tests/async/test_server.py
@@ -1009,20 +1009,6 @@ class TestAsyncServer:
         for header, value in headers:
             assert header != 'Set-Cookie'
 
-    async def test_logger(self):
-        s = async_server.AsyncServer(logger=False)
-        assert s.logger.getEffectiveLevel() == logging.ERROR
-        s.logger.setLevel(logging.NOTSET)
-        s = async_server.AsyncServer(logger=True)
-        assert s.logger.getEffectiveLevel() == logging.INFO
-        s.logger.setLevel(logging.WARNING)
-        s = async_server.AsyncServer(logger=True)
-        assert s.logger.getEffectiveLevel() == logging.WARNING
-        s.logger.setLevel(logging.NOTSET)
-        my_logger = logging.Logger('foo')
-        s = async_server.AsyncServer(logger=my_logger)
-        assert s.logger == my_logger
-
     async def test_custom_json(self):
         # Warning: this test cannot run in parallel with other tests, as it
         # changes the JSON encoding/decoding functions

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -51,20 +51,6 @@ class TestClient:
         assert packet.Packet.json == 'foo'
         packet.Packet.json = json
 
-    def test_logger(self):
-        c = client.Client(logger=False)
-        assert c.logger.getEffectiveLevel() == logging.ERROR
-        c.logger.setLevel(logging.NOTSET)
-        c = client.Client(logger=True)
-        assert c.logger.getEffectiveLevel() == logging.INFO
-        c.logger.setLevel(logging.WARNING)
-        c = client.Client(logger=True)
-        assert c.logger.getEffectiveLevel() == logging.WARNING
-        c.logger.setLevel(logging.NOTSET)
-        my_logger = logging.Logger('foo')
-        c = client.Client(logger=my_logger)
-        assert c.logger == my_logger
-
     def test_custom_timeout(self):
         c = client.Client()
         assert c.request_timeout == 5

--- a/tests/common/test_logging.py
+++ b/tests/common/test_logging.py
@@ -1,0 +1,35 @@
+from logging import getLogger
+
+from pytest import mark, warns
+
+from engineio.async_client import AsyncClient
+from engineio.async_server import AsyncServer
+from engineio.client import Client
+from engineio.server import Server
+
+
+@mark.parametrize(
+    ['cls', 'name'],
+    [
+        (AsyncClient, 'engineio.client'),
+        (AsyncServer, 'engineio.server'),
+        (Client, 'engineio.client'),
+        (Server, 'engineio.server'),
+    ],
+)
+class TestLoggingSetup:
+    @mark.parametrize('value', [False, True])
+    def test_bool_logger_deprecation_warning(self, cls, name, value):
+        with warns(
+            DeprecationWarning,
+            match=r'The logger parameter as a boolean is deprecated',
+        ):
+            o = cls(logger=value)
+        assert o.logger is getLogger(name)
+
+    def test_custom_logger(self, cls, name):
+        logger = getLogger('foo')
+        assert cls(logger=logger).logger is logger
+
+    def test_default_logger(self, cls, name):
+        assert cls().logger is getLogger(name)

--- a/tests/common/test_server.py
+++ b/tests/common/test_server.py
@@ -1125,20 +1125,6 @@ class TestServer:
         for header, value in start_response.call_args[0][1]:
             assert header != 'Set-Cookie'
 
-    def test_logger(self):
-        s = server.Server(logger=False)
-        assert s.logger.getEffectiveLevel() == logging.ERROR
-        s.logger.setLevel(logging.NOTSET)
-        s = server.Server(logger=True)
-        assert s.logger.getEffectiveLevel() == logging.INFO
-        s.logger.setLevel(logging.WARNING)
-        s = server.Server(logger=True)
-        assert s.logger.getEffectiveLevel() == logging.WARNING
-        s.logger.setLevel(logging.NOTSET)
-        my_logger = logging.Logger('foo')
-        s = server.Server(logger=my_logger)
-        assert s.logger == my_logger
-
     def test_custom_json(self):
         # Warning: this test cannot run in parallel with other tests, as it
         # changes the JSON encoding/decoding functions


### PR DESCRIPTION
I was playing around with socketio/engineio and stumbled upon dubious behavior. Some of my logs got duplicated! Upon investigation, I've found that engineio adds `StreamHandler` to the default logger. Which is unexpected, to say the least. Documentation was also misleading, since passing `logger=False` does not disable this behavior, just sets different log level.

Note: I'm observing this behavior because I'm configuring loggers after instantiating the app, but before running it. Questionable architecture decision for sure, but I do not think I'm alone in this regard.

So, my proposal is following:
* Do not mess with loggers, accept whatever user passed or fallback to default. It's not the library responsibility to configure loggers after all.
* Remove misleading documentation section. Since there are no additional logic here now, I do not think wording like "if you need more debug-ability - configure logging" would fit.