### PR TITLE
Fix SSL race condition during WebSocket connection handshake

### DIFF
--- a/src/engineio/client.py
+++ b/src/engineio/client.py
@@ -404,6 +404,40 @@ class Client(base_client.BaseClient):
             self.state = 'connected'
             base_client.connected_clients.append(self)
             self._trigger_event('connect', run_async=False)
+
+            # Flush any packets queued by the connect event handler (e.g.,
+            # Socket.IO CONNECT) and receive the response synchronously.
+            # This avoids a race condition where concurrent send/recv on SSL
+            # sockets can corrupt the connection.
+            try:
+                while True:
+                    pkt = self.queue.get_nowait()
+                    if pkt is None:
+                        self.queue.task_done()
+                        break
+                    self.logger.info(
+                        'Sending packet %s data %s (during handshake)',
+                        packet.packet_names[pkt.packet_type],
+                        pkt.data if not isinstance(pkt.data, bytes)
+                        else '<binary>')
+                    if pkt.binary:
+                        ws.send_binary(pkt.encode())
+                    else:
+                        ws.send(pkt.encode())
+                    self.queue.task_done()
+            except self.queue_empty:
+                pass
+
+            # Receive the response (e.g., Socket.IO CONNECT ACK) synchronously
+            try:
+                p = ws.recv()
+                if p:
+                    pkt = packet.Packet(encoded_packet=p)
+                    self._receive_packet(pkt)
+            except Exception:  # pragma: no cover
+                # If recv fails here, the read loop will handle it
+                pass
+
         self.ws = ws
         self.ws.settimeout(self.ping_interval + self.ping_timeout)
 


### PR DESCRIPTION
## Summary
- Fixes ~30-55% connection failure rate when using `socketio.Client` over TLS with `reconnection=False`
- Flushes queued packets and receives response synchronously before starting background threads
- No API changes

## Problem

When connecting via WebSocket over SSL/TLS, the client starts background threads (`_write_loop` and `_read_loop_websocket`) immediately after triggering the 'connect' event. The Socket.IO CONNECT packet ("40") is sent via the write thread while the read thread simultaneously waits for the ACK ("40{sid}").

This concurrent send/recv corrupts the SSL socket's internal state because Python's SSL sockets are not thread-safe for simultaneous read+write operations. The connection dies without a WebSocket close frame.

Related issue: https://github.com/miguelgrinberg/python-socketio/issues/1568

## Solution

After the connect event triggers (which queues the Socket.IO CONNECT packet), flush the queue and receive the response **synchronously in the main thread** before starting background threads. This serializes the critical handshake phase while still allowing concurrent send/recv after the connection is established.