### PR TITLE
Fire disconnect event when write loop times out on empty queue

### DIFF
--- a/src/engineio/async_client.py
+++ b/src/engineio/async_client.py
@@ -638,6 +638,15 @@ class AsyncClient(base_client.BaseClient):
                 packets = [await asyncio.wait_for(self.queue.get(), timeout)]
             except (self.queue_empty, asyncio.TimeoutError):
                 self.logger.error('packet queue is empty, aborting')
+                # signal the read loop to exit so it fires the disconnect event
+                if self.current_transport == 'websocket' and \
+                        self.ws is not None:
+                    try:
+                        await self.ws.close()
+                    except Exception as e:
+                        self.logger.warning('Error closing WebSocket: %s', e)
+                else:
+                    self.write_loop_task = None
                 break
             except asyncio.CancelledError:  # pragma: no cover
                 break

--- a/src/engineio/client.py
+++ b/src/engineio/client.py
@@ -584,6 +584,15 @@ class Client(base_client.BaseClient):
                 packets = [self.queue.get(timeout=timeout)]
             except self.queue_empty:
                 self.logger.error('packet queue is empty, aborting')
+                # signal the read loop to exit so it fires the disconnect event
+                if self.current_transport == 'websocket' and \
+                        self.ws is not None:
+                    try:
+                        self.ws.close()
+                    except Exception as e:
+                        self.logger.warning('Error closing WebSocket: %s', e)
+                else:
+                    self.write_loop_task = None
                 break
             if packets == [None]:
                 self.queue.task_done()

--- a/tests/async/test_client.py
+++ b/tests/async/test_client.py
@@ -1212,6 +1212,95 @@ class TestAsyncClient:
         await c._write_loop()
         c.queue.get.assert_awaited_once_with()
 
+    async def test_write_loop_empty_queue_polling(self):
+        c = async_client.AsyncClient()
+        c.state = 'connected'
+        c.ping_interval = 1
+        c.ping_timeout = 2
+        c.current_transport = 'polling'
+        self.mock_queue(c)
+        c.queue.get = mock.AsyncMock(side_effect=c.queue_empty)
+        c.write_loop_task = mock.MagicMock()
+        await c._write_loop()
+        assert c.write_loop_task is None
+        c.queue.get.assert_awaited_once_with()
+
+    async def test_write_loop_empty_queue_websocket(self):
+        c = async_client.AsyncClient()
+        c.state = 'connected'
+        c.ping_interval = 1
+        c.ping_timeout = 2
+        c.current_transport = 'websocket'
+        self.mock_queue(c)
+        c.queue.get = mock.AsyncMock(side_effect=c.queue_empty)
+        c.ws = mock.MagicMock()
+        c.ws.close = mock.AsyncMock()
+        c.write_loop_task = mock.MagicMock()
+        await c._write_loop()
+        # websocket unblocks the read loop by closing the socket, not by
+        # nulling write_loop_task (which the websocket read loop ignores)
+        c.ws.close.assert_awaited_once_with()
+        assert c.write_loop_task is not None
+        c.queue.get.assert_awaited_once_with()
+
+    async def test_write_loop_empty_queue_propagates_disconnect(self):
+        """Async counterpart of the threading test of the same name: on a
+        WebSocket write-loop timeout the loop closes the WebSocket so the read
+        loop unblocks and fires exactly one disconnect event."""
+        c = async_client.AsyncClient()
+        c.state = 'connected'
+        c.ping_interval = 1
+        c.ping_timeout = 2
+        c.current_transport = 'websocket'
+        base_client.connected_clients.append(c)
+
+        disconnect_calls = []
+        c.on('disconnect', lambda reason: disconnect_calls.append(reason))
+
+        # queue.get() raises immediately, simulating write-loop timeout expiry
+        self.mock_queue(c)
+        c.queue.get = mock.AsyncMock(side_effect=c.queue_empty)
+
+        # ws.receive() blocks until ws.close() signals it, then raises
+        ws_closed = asyncio.Event()
+
+        async def fake_receive():
+            await ws_closed.wait()
+            raise aiohttp.client_exceptions.ServerDisconnectedError()
+
+        async def fake_close():
+            ws_closed.set()
+
+        ws = mock.MagicMock()
+        ws.receive = fake_receive
+        ws.close = fake_close
+        c.ws = ws
+
+        write_task = asyncio.ensure_future(c._write_loop())
+        read_task = asyncio.ensure_future(c._read_loop_websocket())
+        c.write_loop_task = write_task
+
+        try:
+            done, pending = await asyncio.wait(
+                {write_task, read_task}, timeout=1
+            )
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except BaseException:
+                    pass
+
+            assert write_task.done(), 'write_loop_task should have exited'
+            assert c.state != 'connected', \
+                'client must not remain connected after write loop timeout'
+            assert len(disconnect_calls) == 1, \
+                f'expected 1 disconnect callback, got {len(disconnect_calls)}'
+        finally:
+            ws_closed.set()
+            if c in base_client.connected_clients:
+                base_client.connected_clients.remove(c)
+
     async def test_write_loop_polling_one_packet(self):
         c = async_client.AsyncClient()
         c.base_url = 'http://foo'

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -1,5 +1,6 @@
 import logging
 import ssl
+import threading
 import time
 from unittest import mock
 
@@ -1508,6 +1509,98 @@ class TestClient:
         c.queue.get.side_effect = c.queue_empty
         c._write_loop()
         c.queue.get.assert_called_once_with(timeout=7)
+
+    def test_write_loop_empty_queue_polling(self):
+        c = client.Client()
+        c.state = 'connected'
+        c.ping_interval = 1
+        c.ping_timeout = 2
+        c.current_transport = 'polling'
+        self.mock_queue(c)
+        c.queue.get.side_effect = c.queue_empty
+        c.write_loop_task = mock.MagicMock()
+        c._write_loop()
+        assert c.write_loop_task is None
+        c.queue.get.assert_called_once_with(timeout=7)
+
+    def test_write_loop_empty_queue_websocket(self):
+        c = client.Client()
+        c.state = 'connected'
+        c.ping_interval = 1
+        c.ping_timeout = 2
+        c.current_transport = 'websocket'
+        self.mock_queue(c)
+        c.queue.get.side_effect = c.queue_empty
+        c.ws = mock.MagicMock()
+        c.write_loop_task = mock.MagicMock()
+        c._write_loop()
+        # websocket unblocks the read loop by closing the socket, not by
+        # nulling write_loop_task (which the websocket read loop ignores)
+        c.ws.close.assert_called_once_with()
+        assert c.write_loop_task is not None
+        c.queue.get.assert_called_once_with(timeout=7)
+
+    def test_write_loop_empty_queue_propagates_disconnect(self):
+        """
+        When _write_loop's queue.get() times out (queue stays empty for
+        max(ping_interval, ping_timeout)+5 seconds), the write loop must close
+        the WebSocket so _read_loop_websocket's error path fires on_disconnect.
+
+        The asymmetry bug: write-loop timeout (max(ping_interval,
+        ping_timeout)+5, e.g. 40s) can expire while the read-loop recv()
+        timeout (ping_interval+ping_timeout, e.g. 60s) has not. The write loop
+        exits silently, leaving state='connected', no on_disconnect callback,
+        and the read loop alive indefinitely receiving pings it can't answer.
+        """
+        c = client.Client()
+        c.state = 'connected'
+        c.ping_interval = 1
+        c.ping_timeout = 2
+        c.current_transport = 'websocket'
+        base_client.connected_clients.append(c)
+
+        disconnect_calls = []
+        c.on('disconnect', lambda reason: disconnect_calls.append(reason))
+
+        # queue.get() raises immediately, simulating write-loop timeout expiry
+        self.mock_queue(c)
+        c.queue.get.side_effect = c.queue_empty
+
+        # ws.recv() blocks until ws.close() signals it, then raises;
+        # this faithfully models a server that never enforces PONG timeouts
+        ws_closed = threading.Event()
+
+        def fake_recv():
+            ws_closed.wait()
+            raise websocket.WebSocketConnectionClosedException()
+
+        ws = mock.MagicMock()
+        ws.recv.side_effect = fake_recv
+        ws.close.side_effect = lambda: ws_closed.set()
+        c.ws = ws
+
+        write_thread = threading.Thread(target=c._write_loop, daemon=True)
+        read_thread = threading.Thread(target=c._read_loop_websocket,
+                                       daemon=True)
+        c.write_loop_task = write_thread
+
+        try:
+            write_thread.start()
+            read_thread.start()
+
+            write_thread.join(timeout=1)
+            read_thread.join(timeout=1)
+
+            assert not write_thread.is_alive(), \
+                'write_loop_task should have exited'
+            assert c.state != 'connected', \
+                'client must not remain connected after write loop timeout'
+            assert len(disconnect_calls) == 1, \
+                f'expected 1 disconnect callback, got {len(disconnect_calls)}'
+        finally:
+            ws_closed.set()  # unblock fake_recv so the daemon thread can exit
+            if c in base_client.connected_clients:
+                base_client.connected_clients.remove(c)
 
     def test_write_loop_polling_one_packet(self):
         c = client.Client()


### PR DESCRIPTION
## Motivation

We hit this in production with the threading websocket client: it was left permanently in the `connected` state with no `on_disconnect` ever firing, even though the underlying connection was dead. Because the disconnect event never fired, application-level reconnect logic never triggered, and the client stayed wedged until we recreated it (instantiating a fresh client and reconnecting).

## Problem

When `_write_loop`'s `queue.get(timeout=...)` expires — because the server stopped sending pings and no PONG was queued — the client silently exits the write loop without closing the connection or notifying user code.

The root cause is a timeout asymmetry between the two background loops:

- write loop: `max(ping_interval, ping_timeout) + 5` (40s with defaults)
- websocket read loop `recv()`: `ping_interval + ping_timeout` (60s with defaults)

When the write loop's timeout expires first, `_read_loop_websocket` is still alive — it keeps receiving server pings, each one enqueuing a PONG that will never be sent. The client never fires `on_disconnect` and never transitions out of the `connected` state. This wedge can persist indefinitely against a server that keeps sending occasional traffic but doesn't enforce its own PONG timeout.

In Engine.IO v4 the client only PONGs in response to server pings (it never originates pings), so on an idle connection the write queue's only natural feeder is that PONG. The empty-queue timeout therefore only fires when the server has genuinely stopped pinging for ~40s — i.e. a dead connection — making silent abort the wrong response.

## Fix

In the empty-queue branch of `_write_loop`, wake the read loop in a transport-correct way so its **existing** exit path owns the disconnect (fires the event, removes the client from `connected_clients`, resets state):

- **websocket** → `self.ws.close()`, which unblocks the read loop blocked in `recv()` / `receive()`. This mirrors what `disconnect()` already does.
- **polling** → `self.write_loop_task = None`, which makes `_read_loop_polling`'s `while self.state == 'connected' and self.write_loop_task:` condition fall through — the same mechanism already used by the polling HTTP-error path.

The write loop never fires the disconnect event itself, preserving the codebase's single-owner invariant (the read loop is the sole place that triggers `disconnect` / `_reset()`), so there is no double-fire. Graceful `disconnect()` is unaffected: it enqueues `None` first, so the write loop exits through the normal sentinel path, never this timeout branch.

The same change is applied to `asyncio_client.py`.

## Testing

New tests in both `tests/common/test_client.py` and `tests/async/test_client.py`:

- `test_write_loop_empty_queue_polling` / `..._websocket` — focused unit tests pinning each branch (polling nulls `write_loop_task`; websocket calls `ws.close()` and leaves `write_loop_task` truthy).
- `test_write_loop_empty_queue_propagates_disconnect` — end-to-end test running `_write_loop` and `_read_loop_websocket` concurrently (real threads / asyncio tasks), asserting the client leaves `connected` and fires exactly one `on_disconnect`.

All new tests fail on `main` (state stays `connected`) and pass with the fix. Full suite passes and `tox -eflake8` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)